### PR TITLE
Update to latest geoserver-node-client version

### DIFF
--- a/geoserver-init/package.json
+++ b/geoserver-init/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "child_process": "^1.0.2",
-    "geoserver-node-client": "github:jakobmiksch/geoserver-node-client#e54569d4a9be4335d219ee3e41ec668b7e04b38f",
+    "geoserver-node-client": "github:jakobmiksch/geoserver-node-client#53d8fa48ebbd3a3f61d47f15ab41e88a95e8af61",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- fixes #14 
- this PR already tests the latest version of `geoserver-node-client` which will become version `v1.0` once released
- [ ] the entry in `package.json` should be changed to the package of npm