### PR TITLE
Add timestamp to docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Get current timestamp
+        id: timestamp
+        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M')"
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -30,4 +34,7 @@ jobs:
         with:
           context: ./geoserver-init
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/geoserver-init:latest
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/geoserver-init:latest
+            ghcr.io/${{ github.repository_owner }}/geoserver-init:${{ steps.date.outputs.timestamp }}
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,5 +36,5 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/geoserver-init:latest
-            ghcr.io/${{ github.repository_owner }}/geoserver-init:${{ steps.date.outputs.timestamp }}
+            ghcr.io/${{ github.repository_owner }}/geoserver-init:${{ steps.timestamp.outputs.timestamp }}
 


### PR DESCRIPTION
* fixes #13
* add a timestamp tag to the created Docker image
* shall make it easier to try former images
* an alternative would be to use a git commit hash as tag. 
  * pro: easy link to respective commit in code
  * con: finding out which tag is later or earlier does not work so easy as with timestamps
