### PR TITLE
Add workflow json for publish an imagemosaic

### DIFF
--- a/workflows/publish-imagemosaic.json
+++ b/workflows/publish-imagemosaic.json
@@ -1,0 +1,24 @@
+{
+    "job": [
+      {
+        "id": 123,
+        "type": "download-file",
+        "inputs": [
+            "http://nginx/sample.tif",
+            "/opt/geoserver_data/sample.tif"
+          ]
+      },
+      {
+        "id": 456,
+        "type": "geoserver-publish-imagemosaic",
+        "inputs": [
+            "klips",
+            "time_test",
+            {
+              "outputOfId": 123,
+              "outputIndex": 0
+            }
+          ]
+      }
+    ]
+}


### PR DESCRIPTION
This adds a simple job example for a) downloading a geotif and b) publish it to an existing imagemosaic coverage store.

@weskamm please check.