### PR TITLE
Add geoserver data dir as volume to API as its required now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - 127.0.0.1:3000:3000
     volumes:
       - ./klips-api-config:/klips-conf
+      - ./geoserver_data:/opt/geoserver_data/:Z
 
   rabbitmq:
     image: rabbitmq:3.10-management


### PR DESCRIPTION
As the title says, the data dir is required by the API, so we add it.