### PR TITLE
Add create-imagemosaic-datastore worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
     - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
 
   geoserver-publish-imagemosaic:
-    image: ghcr.io/klips-project/mqm-worker/geoserver-publish-imagemosaic
+    image: ghcr.io/klips-project/mqm-worker/geoserver-publish-imagemosaic:latest
     restart: unless-stopped
     volumes:
       - ./geoserver_data:/opt/geoserver_data/:Z
@@ -146,6 +146,23 @@ services:
     - GEOSERVER_USER=${GEOSERVER_USER}
     - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
 
+  geoserver-create-imagemosaic-datastore:
+    image: ghcr.io/klips-project/mqm-worker/geoserver-publish-imagemosaic:latest
+    restart: unless-stopped
+    volumes:
+      - ./geoserver_data:/opt/geoserver_data/:Z
+    depends_on:
+      - rabbitmq
+    environment:
+    - RABBITHOST=${RABBITMQ_HOSTNAME}
+    - RABBITUSER=${RABBITMQ_DEFAULT_USER}
+    - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
+    - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
+    - WORKERQUEUE=geoserver-create-imagemosaic-datastore
+    - GEOSERVER_REST_URL=http://${GEOSERVER_HOSTNAME}:8080/geoserver/rest/
+    - GEOSERVER_USER=${GEOSERVER_USER}
+    - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
+    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
   download-file:
     image: ghcr.io/klips-project/mqm-worker/download-file:latest
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       - ./geoserver_data:/opt/geoserver_data/:Z
     depends_on:
       - rabbitmq
+      - geoserver
     environment:
     - RABBITHOST=${RABBITMQ_HOSTNAME}
     - RABBITUSER=${RABBITMQ_DEFAULT_USER}
@@ -153,6 +154,7 @@ services:
       - ./geoserver_data:/opt/geoserver_data/:Z
     depends_on:
       - rabbitmq
+      - geoserver
     environment:
     - RABBITHOST=${RABBITMQ_HOSTNAME}
     - RABBITUSER=${RABBITMQ_DEFAULT_USER}
@@ -192,7 +194,7 @@ services:
       - WORKERQUEUE=geotiff-validator
 
   geoserver:
-    image: meggsimum/geoserver:2.21.0
+    image: docker.osgeo.org/geoserver:2.21.1
     restart: unless-stopped
     hostname: ${GEOSERVER_HOSTNAME}
     ports:

--- a/workflows/create-imagemosaic-datastore.json
+++ b/workflows/create-imagemosaic-datastore.json
@@ -1,0 +1,12 @@
+{
+    "job": [
+      {
+        "id": 456,
+        "type": "geoserver-create-imagemosaic-datastore",
+        "inputs": [
+            "klips",
+            "temperature"
+          ]
+      }
+    ]
+}

--- a/workflows/publish-imagemosaic.json
+++ b/workflows/publish-imagemosaic.json
@@ -5,19 +5,28 @@
         "type": "download-file",
         "inputs": [
             "http://nginx/sample.tif",
-            "/opt/geoserver_data/sample.tif"
+            "/opt/geoserver_data/20220101T0000.tif"
           ]
       },
       {
         "id": 456,
+        "type": "geoserver-create-imagemosaic-datastore",
+        "inputs": [
+            "klips",
+            "temperature"
+          ]
+      },
+      {
+        "id": 789,
         "type": "geoserver-publish-imagemosaic",
         "inputs": [
             "klips",
-            "time_test",
+            "temperature",
             {
               "outputOfId": 123,
               "outputIndex": 0
-            }
+            },
+            true
           ]
       }
     ]


### PR DESCRIPTION
This updates the `docker-compose.yml` file by adding the `geoserver-create-imagemosaic-datastore` worker.  
Also adapts the respective job jsons.  

@weskamm @chrismayer what do you think?