### PR TITLE
geoserver-init: Upgrade dependencies and BugFix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,7 @@ services:
         - GEOSERVER_DEFAULT_PASSWORD=${GEOSERVER_DEFAULT_PASSWORD}
         - GEOSERVER_USER=${GEOSERVER_USER}
         - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
-    command: [ "./wait-for.sh", "--timeout=180", "geoserver:8080", "--", "npm", "start"]
+    command: [ "./wait-for.sh", "--timeout=180", "${GEOSERVER_HOSTNAME}:8080", "--", "npm", "start"]
 
   postgres:
     image: postgis/postgis:13-3.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,7 @@ services:
         - GEOSERVER_DEFAULT_PASSWORD=${GEOSERVER_DEFAULT_PASSWORD}
         - GEOSERVER_USER=${GEOSERVER_USER}
         - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
-    command: [ "./wait-for.sh", "${GEOSERVER_HOSTNAME}:8080", "--", "npm", "run", "start"]
+    command: [ "./wait-for.sh", "--timeout=180", "geoserver:8080", "--", "npm", "start"]
 
   postgres:
     image: postgis/postgis:13-3.2

--- a/geoserver-init/000_change_auth.js
+++ b/geoserver-init/000_change_auth.js
@@ -51,6 +51,19 @@ async function adaptSecurity () {
     // disable user
     await grc.security.updateUser(geoserverDefaultUser, geoserverDefaultPw, false);
     console.info('INFO:', 'Successfully disabled default "admin" user');
+
+    // TODO: this is a pragmatic solution to ensure the newly created user can actually log in
+    //       it is required, because the workers often request GeoServer and therefore delay the
+    //       moment until the newly created user is usable.
+    //       Ideally here we have a function that waits for the moment until we can successfully login
+    console.info('INFO:', 'Waiting for 10 seconds to give GeoServer time to register the new user.');
+    function sleep (seconds) {
+      return new Promise((resolve) => {
+        setTimeout(resolve, seconds * 1000);
+      });
+    }
+    await sleep(10);
+    console.info('INFO:', 'Waiting over...');
   } catch (error) {
     console.warn('WARN:', 'Could not log in - credentials have probably been changed already');
   }

--- a/geoserver-init/package-lock.json
+++ b/geoserver-init/package-lock.json
@@ -9,9 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "child_process": "^1.0.2",
-        "geoserver-node-client": "1.1.0",
-        "node-fetch": "^2.6.0"
+        "geoserver-node-client": "1.2.2"
       },
       "devDependencies": {
         "eslint": "^7.23.0",
@@ -160,9 +158,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -341,11 +339,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -988,9 +981,9 @@
       "dev": true
     },
     "node_modules/geoserver-node-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-1.1.0.tgz",
-      "integrity": "sha512-1z+8PQYEIPzoN6c9yAxy0S11ktd7KF5UnmOUeQa7r/0KKa4Ydyn7HK63bHSoQncQ/9uTEnZY/+EbEHiKNHazyQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-1.2.2.tgz",
+      "integrity": "sha512-3akiG/KkH/CgBcdCHMgAv3wWm7W4iBw9unIdPdiMHngn9WY3dXyFV55Gl3bXp98Sl4It4JTHR/9sQZHp9aLoZg==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "node-fetch": "^2.6.5"
@@ -1463,9 +1456,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -2363,9 +2356,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -2498,11 +2491,6 @@
           }
         }
       }
-    },
-    "child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -3004,9 +2992,9 @@
       "dev": true
     },
     "geoserver-node-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-1.1.0.tgz",
-      "integrity": "sha512-1z+8PQYEIPzoN6c9yAxy0S11ktd7KF5UnmOUeQa7r/0KKa4Ydyn7HK63bHSoQncQ/9uTEnZY/+EbEHiKNHazyQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-1.2.2.tgz",
+      "integrity": "sha512-3akiG/KkH/CgBcdCHMgAv3wWm7W4iBw9unIdPdiMHngn9WY3dXyFV55Gl3bXp98Sl4It4JTHR/9sQZHp9aLoZg==",
       "requires": {
         "@babel/runtime": "^7.18.3",
         "node-fetch": "^2.6.5"
@@ -3350,9 +3338,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {

--- a/geoserver-init/package.json
+++ b/geoserver-init/package.json
@@ -7,15 +7,12 @@
   "scripts": {
     "lint": "eslint '**/*.js' --ignore-pattern node_modules/",
     "lint-fix": "eslint --fix '**/*.js' --ignore-pattern node_modules/",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node 000_change_auth.js && node 010_create_workspace.js"
   },
   "author": "meggsimum",
   "license": "MIT",
   "dependencies": {
-    "child_process": "^1.0.2",
-    "geoserver-node-client": "1.1.0",
-    "node-fetch": "^2.6.0"
+    "geoserver-node-client": "1.2.2"
   },
   "devDependencies": {
     "eslint": "^7.23.0",

--- a/worker/rollback-handler/index.js
+++ b/worker/rollback-handler/index.js
@@ -89,4 +89,4 @@ const isGeoServerAvailable = async () => {
 }
 
 // Initialize and start the worker process
-initialize(rabbitHost, rabbitUser, rabbitPass, workerQueue, resultQueue, rollback, isGeoServerAvailable, 10);
+initialize(rabbitHost, rabbitUser, rabbitPass, workerQueue, resultQueue, rollback, isGeoServerAvailable);


### PR DESCRIPTION
- Upgrade and cleanup dependencies
- on a clean setup the geoserver-init script failed, because the newly created user was not availble yet. The reason is probably the heavy load of the workers requesting geoserver and delaying the process of creating  new user. We now add 10 seconds time to wait to ensure the new user is acutally registered