### PR TITLE
Update imagemosaic workflows

### DIFF
--- a/workflows/create-imagemosaic-datastore.json
+++ b/workflows/create-imagemosaic-datastore.json
@@ -1,11 +1,23 @@
 {
     "job": [
       {
+        "id": 123,
+        "type": "download-file",
+        "inputs": [
+            "http://nginx/sample.tif",
+            "/opt/geoserver_data/sample.tif"
+          ]
+      },
+      {
         "id": 456,
         "type": "geoserver-create-imagemosaic-datastore",
         "inputs": [
             "dresden",
-            "dresden_temperature"
+            "dresden_temperature",
+            {
+              "outputOfId": 123,
+              "outputIndex": 0
+            }
           ]
       }
     ]

--- a/workflows/publish-imagemosaic.json
+++ b/workflows/publish-imagemosaic.json
@@ -23,7 +23,11 @@
         "type": "geoserver-create-imagemosaic-datastore",
         "inputs": [
             "langenfeld",
-            "langenfeld_temperature"
+            "langenfeld_temperature",
+            {
+              "outputOfId": 1,
+              "outputIndex": 0
+            }
           ]
       },
       {


### PR DESCRIPTION
After an update of the `create-imagemosaic-datastore` worker, these job-jsons needs to be updated.

@JakobMiksch 