### PR TITLE
pygeoapi: add locationinfo using rasterstats

### DIFF
--- a/pygeoapi/Dockerfile
+++ b/pygeoapi/Dockerfile
@@ -8,7 +8,8 @@ RUN apt -y update && \
 # install 'rasterstats', 'click' needed for compatibility with pygeoapi
 RUN pip3 install rasterstats click==7.1.2
 
-COPY pygeoapi-config.yml /pygeoapi/local.config.yml
-COPY processes /pygeoapi/processes
-COPY process_scripts/ /process_scripts/
 COPY demo_data/ /demo_data/
+
+WORKDIR /pygeoapi
+COPY pygeoapi-config.yml local.config.yml
+COPY processes/ processes/

--- a/pygeoapi/Dockerfile
+++ b/pygeoapi/Dockerfile
@@ -5,6 +5,9 @@ RUN apt -y update && \
     apt -y install grass \
                    gdal-bin
 
+# install 'rasterstats', 'click' needed for compatibility with pygeoapi
+RUN pip3 install rasterstats click==7.1.2
+
 COPY pygeoapi-config.yml /pygeoapi/local.config.yml
 COPY processes /pygeoapi/processes
 COPY process_scripts/ /process_scripts/

--- a/pygeoapi/Dockerfile
+++ b/pygeoapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM geopython/pygeoapi:0.12.0
+FROM geopython/pygeoapi:0.13.0
 
 RUN apt -y update && \
     apt -y upgrade && \

--- a/pygeoapi/README.md
+++ b/pygeoapi/README.md
@@ -10,6 +10,12 @@ using the project's Docker Compose
 docker-compose up --build -d pygeoapi ; docker-compose logs -f
 ```
 
+## Logging
+
+Logging from inside the process can be done using `LOGGER.error('your message')` or `LOGGER.debug('your message')`.
+
+The logging level is defined in the file `pygeoapi-config.yml`.
+
 ## Usage
 
 Example request:

--- a/pygeoapi/processes/algorithms/location_info.py
+++ b/pygeoapi/processes/algorithms/location_info.py
@@ -1,0 +1,37 @@
+from rasterstats import zonal_stats, point_query
+from shapely.geometry import Point
+import httplib2
+
+def get_location_info(cog_url, x, y):
+    """
+    Extracts the value at the location of the first band of the provided COG
+
+    :param cog_url: the URL of the COG
+    :param x: the x coordinate in the same projection as the COG
+    :param y: the y coordinate in the same projection as the COG
+
+    :returns: tuple of headers, status code, content
+    """
+
+    # validate input coordinates
+    try:
+        x = int(x)
+        y = int(y)
+    except:
+        raise Exception('Provided coordinates are not numbers')
+
+    # validate URL of COG
+    try:
+        # request HEAD of URL to check its existence without downloading it
+        response = httplib2.Http().request(cog_url, 'HEAD')
+        assert response[0]['status'] != 200
+    except:
+        raise Exception(
+            'Provided URL does not exist or cannot be reached.')
+
+    # request value from COG
+    point = Point(x, y)
+    response = point_query([point], cog_url)
+
+    return response[0]
+    

--- a/pygeoapi/processes/algorithms/location_info.py
+++ b/pygeoapi/processes/algorithms/location_info.py
@@ -10,7 +10,7 @@ def get_location_info(cog_url, x, y):
     :param x: the x coordinate in the same projection as the COG
     :param y: the y coordinate in the same projection as the COG
 
-    :returns: tuple of headers, status code, content
+    :returns: the value at the location of the first band
     """
 
     # validate input coordinates

--- a/pygeoapi/processes/algorithms/location_info.py
+++ b/pygeoapi/processes/algorithms/location_info.py
@@ -1,4 +1,4 @@
-from rasterstats import zonal_stats, point_query
+from rasterstats import point_query
 from shapely.geometry import Point
 import httplib2
 

--- a/pygeoapi/processes/algorithms/location_info.py
+++ b/pygeoapi/processes/algorithms/location_info.py
@@ -34,4 +34,4 @@ def get_location_info(cog_url, x, y):
     response = point_query([point], cog_url)
 
     return response[0]
-    
+

--- a/pygeoapi/processes/algorithms/zonal_stats.sh
+++ b/pygeoapi/processes/algorithms/zonal_stats.sh
@@ -15,7 +15,8 @@ IN_GEOTIFF_PATH="${2}"
 echo "${IN_GEOJSON_CONTENT}" |
   gdalwarp \
     -cutline /vsistdin/ \
-    -crop_to_cutline "${IN_GEOTIFF_PATH}" \
+    -crop_to_cutline \
+    "${IN_GEOTIFF_PATH}" \
     /vsistdout/ |
   gdalinfo \
     -json \

--- a/pygeoapi/processes/location_info_rasterstats.py
+++ b/pygeoapi/processes/location_info_rasterstats.py
@@ -46,7 +46,7 @@ PROCESS_METADATA = {
     },
     'description': {
         'en': 'Get information of a location of an publicly accessible COG. Only queries the data from the first raster band.',
-        'de': 'Gibt Informationen über einen Standort eines öffentlich zugänglichen COGs zurück. Frägt nur Daten vom ersten Rasterband ab.'
+        'de': 'Gibt Informationen über einen Standort eines öffentlich zugänglichen COGs zurück. Fragt nur Daten vom ersten Rasterband ab.'
     },
     'keywords': ['rasterstats', 'locationinfo', 'featureinfo'],
     'links': [],

--- a/pygeoapi/processes/location_info_rasterstats.py
+++ b/pygeoapi/processes/location_info_rasterstats.py
@@ -52,8 +52,8 @@ PROCESS_METADATA = {
     'links': [],
     'inputs': {
         'x': {
-            'title': 'X coordinate',
-            'description': 'The x coordinate of point to query. Must be in the same projection as the COG.',
+            'title': 'x value',
+            'description': 'The x value of point to query. Must be in the same projection as the COG.',
             'schema': {
                 'type': 'string'
             },
@@ -61,8 +61,8 @@ PROCESS_METADATA = {
             'maxOccurs': 1,
         },
         'y': {
-            'title': 'Y coordinate',
-            'description': 'The y coordinate of point to query. Must be in the same projection as the COG.',
+            'title': 'y value',
+            'description': 'The y value of point to query. Must be in the same projection as the COG.',
             'schema': {
                 'type': 'string'
             },

--- a/pygeoapi/processes/location_info_rasterstats.py
+++ b/pygeoapi/processes/location_info_rasterstats.py
@@ -52,8 +52,8 @@ PROCESS_METADATA = {
     'links': [],
     'inputs': {
         'x': {
-            'title': 'x value',
-            'description': 'The x value of point to query. Must be in the same projection as the COG.',
+            'title': 'X coordinate',
+            'description': 'The x coordinate of point to query. Must be in the same projection as the COG.',
             'schema': {
                 'type': 'string'
             },
@@ -61,8 +61,8 @@ PROCESS_METADATA = {
             'maxOccurs': 1,
         },
         'y': {
-            'title': 'y value',
-            'description': 'The y value of point to query. Must be in the same projection as the COG.',
+            'title': 'Y coordinate',
+            'description': 'The y coordinate of point to query. Must be in the same projection as the COG.',
             'schema': {
                 'type': 'string'
             },

--- a/pygeoapi/processes/location_info_rasterstats.py
+++ b/pygeoapi/processes/location_info_rasterstats.py
@@ -52,22 +52,40 @@ PROCESS_METADATA = {
     'links': [],
     'inputs': {
         'x': {
-            'title': 'The x value',
-            'description': 'The x value of point to query. Must be in the same projection as the COG.'
+            'title': 'x value',
+            'description': 'The x value of point to query. Must be in the same projection as the COG.',
+            'schema': {
+                'type': 'string'
+            },
+            'minOccurs': 1,
+            'maxOccurs': 1,
         },
         'y': {
-            'title': 'The y value',
-            'description': 'The y value of point to query. Must be in the same projection as the COG.'
+            'title': 'y value',
+            'description': 'The y value of point to query. Must be in the same projection as the COG.',
+            'schema': {
+                'type': 'string'
+            },
+            'minOccurs': 1,
+            'maxOccurs': 1
         },
         'cogUrl': {
-            'title': 'The URL of the COG',
-            'description': 'The public available URL of the COG to query'
+            'title': 'URL of the COG',
+            'description': 'The public available URL of the COG to query',
+            'schema': {
+                'type': 'string'
+            },
+            'minOccurs': 1,
+            'maxOccurs': 1
         }
     },
     'outputs': {
         'value': {
-            'title': 'The value',
-            'description': 'The value of the location at the first band of the COG.'
+            'title': 'location value',
+            'description': 'The value of the location at the first band of the COG.',
+            'schema': {
+                'type': 'string'
+            }
         }
     },
     'example': {

--- a/pygeoapi/processes/location_info_rasterstats.py
+++ b/pygeoapi/processes/location_info_rasterstats.py
@@ -1,0 +1,125 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2019 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import logging
+from rasterstats import zonal_stats, point_query
+from shapely.geometry import Point
+import httplib2
+
+
+from pygeoapi.process.base import BaseProcessor, ProcessorExecuteError
+import json
+
+LOGGER = logging.getLogger(__name__)
+
+#: Process metadata and description
+PROCESS_METADATA = {
+    'version': '0.1.0',
+    'id': 'location-info-rasterstats',
+    'title': {
+        'en': 'Location info of a COG using rasterstats',
+        'de': 'Standortinformation eines COGs mit rasterstats'
+    },
+    'description': {
+        'en': 'Get information of a location of an publicly accessible COG. Only queries the data from the first raster band.',
+        'de': 'Gibt Informationen über einen Standort eines öffentlich zugänglichen COGs zurück. Frägt nur Daten vom ersten Rasterband ab.'
+    },
+    'keywords': ['rasterstats', 'locationinfo', 'featureinfo'],
+    'links': [],
+    'inputs': {
+        'x': {
+            'title': 'The x value',
+            'description': 'The x value of point to query. Must be in the same projection as the COG.'
+        },
+        'y': {
+            'title': 'The y value',
+            'description': 'The y value of point to query. Must be in the same projection as the COG.'
+        },
+        'cogUrl': {
+            'title': 'The URL of the COG',
+            'description': 'The public available URL of the COG to query'
+        }
+    },
+    'outputs': {
+        'value': {
+            'title': 'The value',
+            'description': 'The value of the location at the first band of the COG.'
+        }
+    },
+    'example': {
+        "inputs": {
+            "x": 12.2,
+            "y": 50.4,
+            "cogUrl": "https://example.com/sample-cog.tif"
+        }
+    }
+}
+
+
+class LocationInfoRasterstatsProcessor(BaseProcessor):
+
+    def __init__(self, processor_def):
+        super().__init__(processor_def, PROCESS_METADATA)
+
+    def execute(self, data):
+
+        # validate input coordinates
+        x = data.get('x', None)
+        y = data.get('y', None)
+        try:
+            x = int(x)
+            y = int(y)
+        except:
+            raise ProcessorExecuteError('Provided coordinates are not numbers')
+
+        # validate URL of COG
+        cog_url = data.get('cogUrl', None)
+        try:
+            # request HEAD of URL to check its existence without downloading it
+            response = httplib2.Http().request(cog_url, 'HEAD')
+            assert response[0]['status'] != 200
+        except:
+            raise ProcessorExecuteError(
+                'Provided URL does not exist or cannot be reached.')
+
+        # request value from COG
+        point = Point(x, y)
+        response = point_query([point], cog_url)
+
+        value = response[0]
+
+        outputs = {
+            'value': value
+        }
+
+        mimetype = 'application/json'
+        return mimetype, outputs
+
+    def __repr__(self):
+        return '<LocationInfoRasterstatsProcessor> {}'.format(self.name)

--- a/pygeoapi/processes/location_info_rasterstats.py
+++ b/pygeoapi/processes/location_info_rasterstats.py
@@ -105,9 +105,9 @@ class LocationInfoRasterstatsProcessor(BaseProcessor):
 
     def execute(self, data):
 
-        y = data.get('y', None)
-        x = data.get('x', None)
-        cog_url = data.get('cogUrl', None)
+        y = data.get('y')
+        x = data.get('x')
+        cog_url = data.get('cogUrl')
 
         value = get_location_info(cog_url, x, y)
 

--- a/pygeoapi/processes/location_info_rasterstats.py
+++ b/pygeoapi/processes/location_info_rasterstats.py
@@ -46,7 +46,7 @@ PROCESS_METADATA = {
     },
     'description': {
         'en': 'Get information of a location of an publicly accessible COG. Only queries the data from the first raster band.',
-        'de': 'Gibt Informationen über einen Standort eines öffentlich zugänglichen COGs zurück. Fragt nur Daten vom ersten Rasterband ab.'
+        'de': 'Fragt Rasterwerte eines öffentlich zugänglichen COG basierend auf Input-Koordinaten ab. Dabei wird nur das erste Band abgefragt.'
     },
     'keywords': ['rasterstats', 'locationinfo', 'featureinfo'],
     'links': [],

--- a/pygeoapi/processes/zonal_statistics_gdal.py
+++ b/pygeoapi/processes/zonal_statistics_gdal.py
@@ -120,7 +120,7 @@ class ZonalStatisticsGdalProcessor(BaseProcessor):
 
         raw_output = subprocess.run(
             [
-                '/process_scripts/zonal_stats.sh',
+                '/pygeoapi/process_scripts/algorithms/zonal_stats.sh',
                 jsonString,
                 geoTiffPath
             ],

--- a/pygeoapi/processes/zonal_statistics_gdal.py
+++ b/pygeoapi/processes/zonal_statistics_gdal.py
@@ -40,11 +40,12 @@ PROCESS_METADATA = {
     'version': '0.1.0',
     'id': 'zonal-statistics-gdal',
     'title': {
-        'en': 'Zonal statistics with GDAL'
+        'en': 'Zonal statistics with GDAL',
+        'de': 'Zonale Statistiken mit GDAL'
     },
     'description': {
         'en': 'Takes a GeoJSON and computes zonal statistics of a demo raster file using GDAL.',
-        'en': 'Berechnet einfache zonale Statistiken auf Basis einer Demo Rasterdatei mit Hilfe von GDAL.'
+        'de': 'Berechnet einfache zonale Statistiken auf Basis einer Demo Rasterdatei mit Hilfe von GDAL.'
     },
     'keywords': ['gdal', 'zonal', 'statistics', 'raster'],
     'links': [],

--- a/pygeoapi/pygeoapi-config.yml
+++ b/pygeoapi/pygeoapi-config.yml
@@ -95,6 +95,11 @@ resources:
         processor:
             name: processes.zonal_statistics_gdal.ZonalStatisticsGdalProcessor
 
+    location-info-rasterstats:
+        type: process
+        processor:
+            name: processes.location_info_rasterstats.LocationInfoRasterstatsProcessor
+
     hello-world:
         type: process
         processor:


### PR DESCRIPTION
- adds a process to query the information of one location in a COG using the Python library [rasterstats](https://pythonhosted.org/rasterstats/index.html)
- `rasterstats` is based on GDAL/OGR. It can query COGs and **only** requests the necessary information. It does **not** download the whole file to perform analysis
- some minor fixes and docs
- the algorithm for the location info is in a separate python to make it possible to run it without pygeoapi (useful for development)
- follow-up PR is https://github.com/klips-project/klips-sdi/pull/87
- Upgrade pygeoapi to 0.13.0 - fixes #88 