### PR TITLE
Fix: pygeoapi import for standalone grass script

### DIFF
--- a/pygeoapi/processes/zonal_statistics_grass.py
+++ b/pygeoapi/processes/zonal_statistics_grass.py
@@ -3,7 +3,7 @@ import logging
 
 from pygeoapi.process.base import BaseProcessor
 
-from pygeoapi.processes.algorithms.standalone_grass_zonal_stats import generate_zonal_stats
+from processes.algorithms.standalone_grass_zonal_stats import generate_zonal_stats
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
This should fix the import of `standalone_grass_zonal` script.  
@weskamm @JakobMiksch please check.