### PR TITLE
Docker compse file: Use container_name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,6 @@ USE_RABBIT_MQ=1
 PARTNER_URL_START=https://www.example.com
 PARTNER_API_USERNAME=dummy
 PARTNER_API_PASSWORD=randompassword
+
+# Docker compose container name prefix
+CN_PREFIX=klips

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   nginx:
-    container_name: klips-nginx
+    container_name: ${CN_PREFIX}-nginx
     image: nginx
     restart: unless-stopped
     ports:
@@ -13,7 +13,7 @@ services:
       - ./cog_data:/opt/cog:ro
 
   klips-api:
-    container_name: klips-klips-api
+    container_name: ${CN_PREFIX}-api
     image: ghcr.io/klips-project/klips-api:latest
     restart: unless-stopped
     depends_on:
@@ -36,7 +36,7 @@ services:
       - ./logs:/home/logs:Z
 
   rabbitmq:
-    container_name: klips-rabbitmq
+    container_name: ${CN_PREFIX}-rabbitmq
     image: rabbitmq:3.10-management
     restart: unless-stopped
     # hostname required for mounted data
@@ -51,7 +51,7 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
 
   dispatcher:
-    container_name: klips-dispatcher
+    container_name: ${CN_PREFIX}-dispatcher
     image: ghcr.io/klips-project/mqm-worker/dispatcher:latest
     restart: unless-stopped
     depends_on:
@@ -66,7 +66,7 @@ services:
       - WORKERQUEUE=dispatcher
 
   error-handler:
-    container_name: klips-error-handler
+    container_name: ${CN_PREFIX}-error-handler
     image: ghcr.io/klips-project/mqm-worker/error-handler:latest
     restart: unless-stopped
     depends_on:
@@ -82,7 +82,7 @@ services:
       - DEV_MODE=1
 
   rollback-handler:
-    container_name: klips-rollback-handler
+    container_name: ${CN_PREFIX}-rollback-handler
     image: ghcr.io/klips-project/mqm-worker/rollback-handler:latest
     restart: unless-stopped
     volumes:
@@ -101,7 +101,7 @@ services:
       - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
 
   send-mattermost-message:
-    container_name: klips-send-mattermost-message
+    container_name: ${CN_PREFIX}-send-mattermost-message
     image: ghcr.io/klips-project/mqm-worker/send-mattermost-message:latest
     restart: unless-stopped
     depends_on:
@@ -118,7 +118,7 @@ services:
       - NODE_TLS_REJECT_UNAUTHORIZED=0
 
   send-email:
-    container_name: klips-send-email
+    container_name: ${CN_PREFIX}-send-email
     image: ghcr.io/klips-project/mqm-worker/send-email:latest
     environment:
       - RABBITHOST=${RABBITMQ_HOSTNAME}
@@ -140,7 +140,7 @@ services:
     restart: unless-stopped
 
   geoserver-publish-imagemosaic:
-    container_name: klips-geoserver-publish-imagemosaic
+    container_name: ${CN_PREFIX}-geoserver-publish-imagemosaic
     image: ghcr.io/klips-project/mqm-worker/geoserver-publish-imagemosaic:latest
     restart: unless-stopped
     volumes:
@@ -161,7 +161,7 @@ services:
     - GEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}
 
   geoserver-create-imagemosaic-datastore:
-    container_name: klips-geoserver-create-imagemosaic-datastore
+    container_name: ${CN_PREFIX}-geoserver-create-imagemosaic-datastore
     image: ghcr.io/klips-project/mqm-worker/geoserver-create-imagemosaic-datastore:latest
     restart: unless-stopped
     volumes:
@@ -188,7 +188,7 @@ services:
     - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
   download-file:
-    container_name: klips-download-file
+    container_name: ${CN_PREFIX}-download-file
     image: ghcr.io/klips-project/mqm-worker/download-file:latest
     restart: unless-stopped
     volumes:
@@ -204,7 +204,7 @@ services:
       - WORKERQUEUE=download-file
 
   geotiff-optimizer:
-    container_name: klips-geotiff-optimizer
+    container_name: ${CN_PREFIX}-geotiff-optimizer
     image: ghcr.io/klips-project/mqm-worker/geotiff-optimizer:latest
     restart: unless-stopped
     volumes:
@@ -221,7 +221,7 @@ services:
       - WORKERQUEUE=geotiff-optimizer
 
   geotiff-validator:
-    container_name: klips-geotiff-validator
+    container_name: ${CN_PREFIX}-geotiff-validator
     image: ghcr.io/klips-project/mqm-worker/geotiff-validator:latest
     restart: unless-stopped
     volumes:
@@ -237,7 +237,7 @@ services:
       - WORKERQUEUE=geotiff-validator
 
   geoserver:
-    container_name: klips-geoserver
+    container_name: ${CN_PREFIX}-geoserver
     image: ghcr.io/klips-project/geoserver:latest
     restart: unless-stopped
     hostname: ${GEOSERVER_HOSTNAME}
@@ -251,7 +251,7 @@ services:
       - SKIP_DEMO_DATA=true
 
   geoserver-init:
-    container_name: klips-geoserver-init
+    container_name: ${CN_PREFIX}-geoserver-init
     image: ghcr.io/klips-project/geoserver-init:latest
     depends_on:
       - geoserver
@@ -266,7 +266,7 @@ services:
     command: [ "./wait-for.sh", "--timeout=180", "${GEOSERVER_HOSTNAME}:8080", "--", "npm", "start"]
 
   postgres:
-    container_name: klips-postgres
+    container_name: ${CN_PREFIX}-postgres
     image: postgis/postgis:13-3.2
     restart: unless-stopped
     volumes:
@@ -280,7 +280,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
 
   pygeoapi:
-    container_name: klips-pygeoapi
+    container_name: ${CN_PREFIX}-pygeoapi
     image: ghcr.io/klips-project/pygeoapi:latest
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 version: '3'
-name: klips
 
 services:
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3'
+name: klips
 
 services:
   nginx:
+    container_name: klips-nginx
     image: nginx
     restart: unless-stopped
     ports:
@@ -12,6 +14,7 @@ services:
       - ./cog_data:/opt/cog:ro
 
   klips-api:
+    container_name: klips-klips-api
     image: ghcr.io/klips-project/klips-api:latest
     restart: unless-stopped
     depends_on:
@@ -34,6 +37,7 @@ services:
       - ./logs:/home/logs:Z
 
   rabbitmq:
+    container_name: klips-rabbitmq
     image: rabbitmq:3.10-management
     restart: unless-stopped
     # hostname required for mounted data
@@ -48,6 +52,7 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
 
   dispatcher:
+    container_name: klips-dispatcher
     image: ghcr.io/klips-project/mqm-worker/dispatcher:latest
     restart: unless-stopped
     depends_on:
@@ -62,6 +67,7 @@ services:
       - WORKERQUEUE=dispatcher
 
   error-handler:
+    container_name: klips-error-handler
     image: ghcr.io/klips-project/mqm-worker/error-handler:latest
     restart: unless-stopped
     depends_on:
@@ -77,6 +83,7 @@ services:
       - DEV_MODE=1
 
   rollback-handler:
+    container_name: klips-rollback-handler
     image: ghcr.io/klips-project/mqm-worker/rollback-handler:latest
     restart: unless-stopped
     volumes:
@@ -95,6 +102,7 @@ services:
       - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
 
   send-mattermost-message:
+    container_name: klips-send-mattermost-message
     image: ghcr.io/klips-project/mqm-worker/send-mattermost-message:latest
     restart: unless-stopped
     depends_on:
@@ -111,6 +119,7 @@ services:
       - NODE_TLS_REJECT_UNAUTHORIZED=0
 
   send-email:
+    container_name: klips-send-email
     image: ghcr.io/klips-project/mqm-worker/send-email:latest
     environment:
       - RABBITHOST=${RABBITMQ_HOSTNAME}
@@ -132,6 +141,7 @@ services:
     restart: unless-stopped
 
   geoserver-publish-imagemosaic:
+    container_name: klips-geoserver-publish-imagemosaic
     image: ghcr.io/klips-project/mqm-worker/geoserver-publish-imagemosaic:latest
     restart: unless-stopped
     volumes:
@@ -152,6 +162,7 @@ services:
     - GEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}
 
   geoserver-create-imagemosaic-datastore:
+    container_name: klips-geoserver-create-imagemosaic-datastore
     image: ghcr.io/klips-project/mqm-worker/geoserver-create-imagemosaic-datastore:latest
     restart: unless-stopped
     volumes:
@@ -178,6 +189,7 @@ services:
     - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
   download-file:
+    container_name: klips-download-file
     image: ghcr.io/klips-project/mqm-worker/download-file:latest
     restart: unless-stopped
     volumes:
@@ -193,6 +205,7 @@ services:
       - WORKERQUEUE=download-file
 
   geotiff-optimizer:
+    container_name: klips-geotiff-optimizer
     image: ghcr.io/klips-project/mqm-worker/geotiff-optimizer:latest
     restart: unless-stopped
     volumes:
@@ -209,6 +222,7 @@ services:
       - WORKERQUEUE=geotiff-optimizer
 
   geotiff-validator:
+    container_name: klips-geotiff-validator
     image: ghcr.io/klips-project/mqm-worker/geotiff-validator:latest
     restart: unless-stopped
     volumes:
@@ -224,6 +238,7 @@ services:
       - WORKERQUEUE=geotiff-validator
 
   geoserver:
+    container_name: klips-geoserver
     image: ghcr.io/klips-project/geoserver:latest
     restart: unless-stopped
     hostname: ${GEOSERVER_HOSTNAME}
@@ -237,6 +252,7 @@ services:
       - SKIP_DEMO_DATA=true
 
   geoserver-init:
+    container_name: klips-geoserver-init
     image: ghcr.io/klips-project/geoserver-init:latest
     depends_on:
       - geoserver
@@ -251,6 +267,7 @@ services:
     command: [ "./wait-for.sh", "--timeout=180", "${GEOSERVER_HOSTNAME}:8080", "--", "npm", "start"]
 
   postgres:
+    container_name: klips-postgres
     image: postgis/postgis:13-3.2
     restart: unless-stopped
     volumes:
@@ -264,6 +281,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
 
   pygeoapi:
+    container_name: klips-pygeoapi
     image: ghcr.io/klips-project/pygeoapi:latest
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Make use of `container_name` variable in docker compose file. https://docs.docker.com/compose/compose-file/compose-file-v3/#container_name  
Why? Increase readability with large amounts of containers.
Possible drawback, no scaling, because name must be unique.  

@chrismayer @JakobMiksch @weskamm 