### PR TITLE
Increase limit filesize GeoTIFF to 20MB

### DIFF
--- a/klips-api/src/config/job-conf.json
+++ b/klips-api/src/config/job-conf.json
@@ -11,7 +11,7 @@
     ],
     "fileSize": {
       "minFileSize": 1000,
-      "maxFileSize": 10000000
+      "maxFileSize": 20000000
     },
     "expectedBandCount": 2,
     "regions": {


### PR DESCRIPTION
- before it was 10MB
- should fix recent error messages from server
