### PR TITLE
Use variable for pygeoapi baseurl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ PARTNER_API_PASSWORD=randompassword
 
 # Docker compose container name prefix
 CN_PREFIX=klips
+
+# pygeoapi
+PYGEOAPI_BASEURL=http://localhost:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -286,6 +286,7 @@ services:
     environment:
       - PYTHONPATH=/usr/lib/grass82/etc/python/
       - GISBASE=/usr/lib/grass82/
+      - PYGEOAPI_BASEURL=${PYGEOAPI_BASEURL}
     ports:
       - 127.0.0.1:5000:80
 

--- a/pygeoapi/pygeoapi-config.yml
+++ b/pygeoapi/pygeoapi-config.yml
@@ -31,7 +31,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 5000
-    url: http://localhost:5000
+    url: ${PYGEOAPI_BASEURL}
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: false


### PR DESCRIPTION
This uses an .env variable to set the base url in `pygeoapi-config.yaml`.  
Needs to be adapted in production, e.g. `https://klips-dev.terrestris.de/pygeoapi`.  

@chrismayer @weskamm @JakobMiksch 