### PR TITLE
Move compose setting to env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,6 @@ CN_PREFIX=klips
 
 # pygeoapi
 PYGEOAPI_BASEURL=http://localhost:5000
+
+# error-handler
+ERROR_HANDLER_DEV_MODE=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
       - RESULTSQUEUE=dispatcher
       - WORKERQUEUE=DeadLetterQueue
-      - DEV_MODE=1
+      - DEV_MODE=${ERROR_HANDLER_DEV_MODE}
 
   rollback-handler:
     container_name: ${CN_PREFIX}-rollback-handler


### PR DESCRIPTION
Move compose setting to env variable, to prevent unnecessary git diffs on the server