### PR TITLE
Separate logging level for stdout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,8 @@ PYGEOAPI_BASEURL=http://localhost:5000
 
 # error-handler
 ERROR_HANDLER_DEV_MODE=1
+
+# The logging level shown in the docker logs
+# 'info' for production
+# 'debug' for development
+PINO_STREAM_LOG_LEVEL=info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - PARTNER_URL_START
       - PARTNER_API_USERNAME
       - PARTNER_API_PASSWORD
+      - PINO_STREAM_LOG_LEVEL
     ports:
       - 127.0.0.1:3000:3000
     volumes:
@@ -64,6 +65,7 @@ services:
       - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
       - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
       - WORKERQUEUE=dispatcher
+      - PINO_STREAM_LOG_LEVEL
 
   error-handler:
     container_name: ${CN_PREFIX}-error-handler
@@ -80,6 +82,7 @@ services:
       - RESULTSQUEUE=dispatcher
       - WORKERQUEUE=DeadLetterQueue
       - DEV_MODE=${ERROR_HANDLER_DEV_MODE}
+      - PINO_STREAM_LOG_LEVEL
 
   rollback-handler:
     container_name: ${CN_PREFIX}-rollback-handler
@@ -99,6 +102,7 @@ services:
       - GEOSERVER_REST_URL=http://${GEOSERVER_HOSTNAME}:8080/geoserver/rest/
       - GEOSERVER_USER=${GEOSERVER_USER}
       - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
+      - PINO_STREAM_LOG_LEVEL
 
   send-mattermost-message:
     container_name: ${CN_PREFIX}-send-mattermost-message
@@ -116,6 +120,7 @@ services:
       - WORKERQUEUE=send-mattermost-message
       - MATTERMOST_HOOK_URL=${MATTERMOST_HOOK_URL}
       - NODE_TLS_REJECT_UNAUTHORIZED=0
+      - PINO_STREAM_LOG_LEVEL
 
   send-email:
     container_name: ${CN_PREFIX}-send-email
@@ -133,6 +138,7 @@ services:
       - AUTHPASS=${MAILAUTHPASS}
       - FROMSENDERNAME=${MAILFROMSENDERNAME}
       - FROMSENDEREMAIL=${MAILFROMSENDEREMAIL}
+      - PINO_STREAM_LOG_LEVEL
     volumes:
       - ./logs:/home/logs:Z
     depends_on:
@@ -150,15 +156,16 @@ services:
       - rabbitmq
       - geoserver
     environment:
-    - RABBITHOST=${RABBITMQ_HOSTNAME}
-    - RABBITUSER=${RABBITMQ_DEFAULT_USER}
-    - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
-    - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
-    - WORKERQUEUE=geoserver-publish-imagemosaic
-    - GEOSERVER_REST_URL=http://${GEOSERVER_HOSTNAME}:8080/geoserver/rest/
-    - GEOSERVER_USER=${GEOSERVER_USER}
-    - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
-    - GEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}
+      - RABBITHOST=${RABBITMQ_HOSTNAME}
+      - RABBITUSER=${RABBITMQ_DEFAULT_USER}
+      - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
+      - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
+      - WORKERQUEUE=geoserver-publish-imagemosaic
+      - GEOSERVER_REST_URL=http://${GEOSERVER_HOSTNAME}:8080/geoserver/rest/
+      - GEOSERVER_USER=${GEOSERVER_USER}
+      - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
+      - GEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}
+      - PINO_STREAM_LOG_LEVEL
 
   geoserver-create-imagemosaic-datastore:
     container_name: ${CN_PREFIX}-geoserver-create-imagemosaic-datastore
@@ -171,21 +178,22 @@ services:
       - rabbitmq
       - geoserver
     environment:
-    - RABBITHOST=${RABBITMQ_HOSTNAME}
-    - RABBITUSER=${RABBITMQ_DEFAULT_USER}
-    - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
-    - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
-    - WORKERQUEUE=geoserver-create-imagemosaic-datastore
-    - GEOSERVER_REST_URL=http://${GEOSERVER_HOSTNAME}:8080/geoserver/rest/
-    - GEOSERVER_USER=${GEOSERVER_USER}
-    - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
-    - GEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}
-    - POSTGRES_HOST=${POSTGRES_HOST}
-    - POSTGRES_PORT=${POSTGRES_PORT}
-    - POSTGRES_SCHEMA=${POSTGRES_SCHEMA}
-    - POSTGRES_DB=${POSTGRES_DB}
-    - POSTGRES_USER=${POSTGRES_USER}
-    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - RABBITHOST=${RABBITMQ_HOSTNAME}
+      - RABBITUSER=${RABBITMQ_DEFAULT_USER}
+      - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
+      - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
+      - WORKERQUEUE=geoserver-create-imagemosaic-datastore
+      - GEOSERVER_REST_URL=http://${GEOSERVER_HOSTNAME}:8080/geoserver/rest/
+      - GEOSERVER_USER=${GEOSERVER_USER}
+      - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
+      - GEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}
+      - POSTGRES_HOST=${POSTGRES_HOST}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_SCHEMA=${POSTGRES_SCHEMA}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - PINO_STREAM_LOG_LEVEL
 
   download-file:
     container_name: ${CN_PREFIX}-download-file
@@ -202,6 +210,7 @@ services:
       - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
       - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
       - WORKERQUEUE=download-file
+      - PINO_STREAM_LOG_LEVEL
 
   geotiff-optimizer:
     container_name: ${CN_PREFIX}-geotiff-optimizer
@@ -219,6 +228,7 @@ services:
       - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
       - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
       - WORKERQUEUE=geotiff-optimizer
+      - PINO_STREAM_LOG_LEVEL
 
   geotiff-validator:
     container_name: ${CN_PREFIX}-geotiff-validator
@@ -235,6 +245,7 @@ services:
       - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
       - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
       - WORKERQUEUE=geotiff-validator
+      - PINO_STREAM_LOG_LEVEL
 
   geoserver:
     container_name: ${CN_PREFIX}-geoserver
@@ -265,6 +276,7 @@ services:
         - GEOSERVER_DEFAULT_PASSWORD=${GEOSERVER_DEFAULT_PASSWORD}
         - GEOSERVER_USER=${GEOSERVER_USER}
         - GEOSERVER_PASSWORD=${GEOSERVER_PASSWORD}
+        - PINO_STREAM_LOG_LEVEL
     command: [ "./wait-for.sh", "--timeout=180", "${GEOSERVER_HOSTNAME}:8080", "--", "npm", "start"]
 
   postgres:

--- a/geoserver-init/logger.js
+++ b/geoserver-init/logger.js
@@ -11,16 +11,25 @@ if (!fs.existsSync(logFilePath)) {
   fs.mkdirSync(dir, { recursive: true });
 }
 
-const logLevel = process.env.LOG_LEVEL || 'debug';
 
 const parentLogger = pino(
   {
-    level: logLevel
+    level: 'debug'
   },
   pino.multistream(
     [
-      { stream: pretty({ colorize: true }), level: logLevel },
-      { stream: pino.destination(logFilePath), level: logLevel }
+      {
+        stream: pretty({
+          colorize: true,
+          // hide worker type, because it is already shown by docker-compose logs
+          // hide pid and hostname, because typically not needed
+          ignore: 'type,pid,hostname',
+          translateTime: 'HH:MM:ss'
+        }),
+        level: process.env.PINO_STREAM_LOG_LEVEL || 'debug'
+      },
+      // write lowest log level to files
+      { stream: pino.destination(logFilePath), level: 'debug' }
     ]
   )
 );

--- a/klips-api/src/logger/index.ts
+++ b/klips-api/src/logger/index.ts
@@ -1,4 +1,4 @@
-import pino from 'pino';
+import pino, { Level } from 'pino';
 import pretty from 'pino-pretty';
 import path from 'path';
 import fs from 'fs';
@@ -11,16 +11,25 @@ if (!fs.existsSync(logFilePath)) {
   fs.mkdirSync(dir, { recursive: true });
 }
 
-const logLevel: any = process.env.LOG_LEVEL || 'debug';
+const streamLogLevel: Level = (process.env.PINO_STREAM_LOG_LEVEL || 'debug') as Level ;
 
 const parentLogger = pino(
   {
-    level: logLevel
+    level: 'debug'
   },
   pino.multistream(
     [
-      { stream: pretty({ colorize: true }), level: logLevel },
-      { stream: pino.destination(logFilePath), level: logLevel },
+      {
+        stream: pretty({
+          colorize: true,
+          // hide worker type, because it is already shown by docker-compose logs
+          // hide pid and hostname, because typically not needed
+          ignore: 'type,pid,hostname',
+          translateTime: 'HH:MM:ss'
+        }),
+        level: streamLogLevel
+      },
+      { stream: pino.destination(logFilePath), level: 'debug' },
     ]
   )
 );

--- a/worker/error-handler/logger.js
+++ b/worker/error-handler/logger.js
@@ -11,16 +11,25 @@ if (!fs.existsSync(logFilePath)) {
   fs.mkdirSync(dir, { recursive: true });
 }
 
-const logLevel = process.env.LOG_LEVEL || 'debug';
 
 const parentLogger = pino(
   {
-    level: logLevel
+    level: 'debug'
   },
   pino.multistream(
     [
-      { stream: pretty({ colorize: true }), level: logLevel },
-      { stream: pino.destination(logFilePath), level: logLevel },
+      {
+        stream: pretty({
+          colorize: true,
+          // hide worker type, because it is already shown by docker-compose logs
+          // hide pid and hostname, because typically not needed
+          ignore: 'type,pid,hostname',
+          translateTime: 'HH:MM:ss'
+        }),
+        level: process.env.PINO_STREAM_LOG_LEVEL || 'debug'
+      },
+      // write lowest log level to files
+      { stream: pino.destination(logFilePath), level: 'debug' },
     ]
   )
 );

--- a/worker/rollback-handler/logger.js
+++ b/worker/rollback-handler/logger.js
@@ -11,16 +11,25 @@ if (!fs.existsSync(logFilePath)) {
   fs.mkdirSync(dir, { recursive: true });
 }
 
-const logLevel = process.env.LOG_LEVEL || 'debug';
 
 const parentLogger = pino(
   {
-    level: logLevel
+    level: 'debug'
   },
   pino.multistream(
     [
-      { stream: pretty({ colorize: true }), level: logLevel },
-      { stream: pino.destination(logFilePath), level: logLevel },
+      {
+        stream: pretty({
+          colorize: true,
+          // hide worker type, because it is already shown by docker-compose logs
+          // hide pid and hostname, because typically not needed
+          ignore: 'type,pid,hostname',
+          translateTime: 'HH:MM:ss'
+        }),
+        level: process.env.PINO_STREAM_LOG_LEVEL || 'debug'
+      },
+      // write lowest log level to files
+      { stream: pino.destination(logFilePath), level: 'debug' },
     ]
   )
 );


### PR DESCRIPTION
- logging level of "stream" that is shown in docker logs can be configured. For example it might be useful to set it to INFO in production enviroments
- logging level for log file will always be DEBUG (the lowest) to be able to understand errors later on