### PR TITLE
Docker config chart api

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,11 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/klips-api:latest
             ghcr.io/${{ github.repository_owner }}/klips-api:${{ steps.timestamp.outputs.timestamp }}
 
-      - name: Build easy-to-use chart api
-        working-directory: ./easy-to-use-api/klips-chart-api
-        run: npm ci && npm run build
+      - name: Build and push klips-chart-api
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./easy-to-use-api/klips-chart-api
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/klips-chart-api:latest
+            ghcr.io/${{ github.repository_owner }}/klips-chart-api:${{ steps.timestamp.outputs.timestamp }}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -57,3 +57,6 @@ services:
 
   pygeoapi:
     build: ./pygeoapi
+
+  easy-to-use-api:
+    build: ./easy-to-use-api/klips-chart-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,11 +314,9 @@ services:
       - ./demonstrator/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./demonstrator/ogc-api-processes:/usr/share/nginx/html/ogc-api-demo:ro
 
-  easy-to-use-api:
-    container_name: ${CN_PREFIX}-easy-to-use-api
-    image: nginx:alpine3.17-slim
+  klips-chart-api:
+    container_name: ${CN_PREFIX}-chart-api
+    image: ghcr.io/klips-project/chart-api:latest
     restart: unless-stopped
     ports:
-      - "3001:80"
-    volumes:
-      - ./easy-to-use-api/klips-chart-api/dist:/usr/share/nginx/html/easy-to-use-api/chart:ro
+      - 3001:80

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -21,6 +21,11 @@ server {
         add_header 'Access-Control-Allow-Origin' '*';
     }
 
+    location /easy-to-use-api/chart/ {
+        proxy_pass http://klips-chart-api:80/klips-chart-api/;
+        add_header 'Access-Control-Allow-Origin' '*';
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html

--- a/pygeoapi/Dockerfile
+++ b/pygeoapi/Dockerfile
@@ -5,9 +5,8 @@ RUN apt -y update && \
     apt -y install software-properties-common && \
     add-apt-repository ppa:ubuntugis/ubuntugis-unstable && \
     apt -y update && \
-    apt -y upgrade
-
-RUN apt -y install grass gdal-bin ffmpeg
+    apt -y upgrade && \
+    apt -y install grass gdal-bin ffmpeg
 
 # NOTE: ensure the minor versions of added libraries are compatible with each other,
 #       otherwise pygeoapi might not start up at all


### PR DESCRIPTION
Use github build and deploy action to create single nginx image ( ~12mb) for the chart api.  
Add nginx location for `/easy-to-use-api/chart`.

