### PR TITLE
Add klips-chart-api Dockerfile

### DIFF
--- a/easy-to-use-api/klips-chart-api/Dockerfile
+++ b/easy-to-use-api/klips-chart-api/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+
+WORKDIR /usr/build
+
+COPY ./ ./
+
+RUN npm ci
+RUN npm run build
+
+FROM nginx:alpine-slim
+
+COPY --from=0 /usr/build/dist/ /usr/share/nginx/html/klips-chart-api


### PR DESCRIPTION
Add Dockerfile (12mb) for chart-api.

please note @weskamm @chrismayer @sdobbert 