### PR TITLE
Improve chart-api echarts bundle

### DIFF
--- a/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
@@ -2,14 +2,55 @@
 import dayjs from 'dayjs';
 import { fetchTimeSeriesData } from '../../service/ogc-api-service';
 import {
-  EChart,
-  EChartsLineSeriesOption, EChartsXaxisOption, EChartsYaxisOption, Params, TimeSeriesData
+  Params,
+  TimeSeriesData
 } from '../../types';
 
-import * as echarts from 'echarts';
+// import echart types
+import {
+  EChartsOption,
+  LineSeriesOption,
+  XAXisComponentOption,
+  YAXisComponentOption,
+} from 'echarts';
+
+import * as echarts from 'echarts/core';
+import {
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  MarkLineComponent,
+  TitleComponent,
+  ToolboxComponent,
+  TooltipComponent,
+  VisualMapComponent
+} from 'echarts/components';
+
+import { LineChart } from 'echarts/charts';
+import { UniversalTransition } from 'echarts/features';
+import { CanvasRenderer } from 'echarts/renderers';
+
+echarts.use([
+  CanvasRenderer,
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  LineChart,
+  MarkLineComponent,
+  TitleComponent,
+  ToolboxComponent,
+  TooltipComponent,
+  UniversalTransition,
+  VisualMapComponent
+]);
+
 import {
   createSeriesData,
-  createVisualMap, createXaxisOptions, createYaxisOptions, formatChartData, setupBaseChart
+  createVisualMap,
+  createXaxisOptions,
+  createYaxisOptions,
+  formatChartData,
+  setupBaseChart
 } from '../../util/Chart';
 
 import WKTParser from 'jsts/org/locationtech/jts/io/WKTParser';
@@ -17,16 +58,16 @@ import WKTParser from 'jsts/org/locationtech/jts/io/WKTParser';
 export class ChartAPI {
   public params: Params;
   public chartData: TimeSeriesData;
-  public chart: EChart;
-  public chartOptions: echarts.EChartsOption;
-  public seriesData: EChartsLineSeriesOption[];
-  public xAxisOptions: EChartsXaxisOption[];
-  public yAxisOptions: EChartsYaxisOption;
+  public chart: echarts.ECharts;
+  public chartOptions: EChartsOption;
+  public seriesData: LineSeriesOption[];
+  public xAxisOptions: XAXisComponentOption[];
+  public yAxisOptions: YAXisComponentOption;
 
   constructor(params: Params, data: any) {
     this.params = params;
     this.chartData = data;
-  
+
     // setup chart
     this.chartOptions = setupBaseChart();
 
@@ -100,7 +141,7 @@ export class ChartAPI {
         visualMap: visualMap
       });
       // add dummy series to display threshold line and markarea
-      const thresholdSeries: echarts.LineSeriesOption = {
+      const thresholdSeries: LineSeriesOption = {
         name: 'threshold dummy series',
         type: 'line',
         silent: true,

--- a/easy-to-use-api/klips-chart-api/src/types/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/types/index.ts
@@ -20,9 +20,3 @@ export type Datapoint = [string, string];
 export type DataPointObject = {
   [key: string]: Datapoint[];
 };
-
-export type EChartsOption = echarts.EChartsOption;
-export type EChart = echarts.ECharts;
-export type EChartsLineSeriesOption = echarts.LineSeriesOption;
-export type EChartsXaxisOption = echarts.XAXisComponentOption;
-export type EChartsYaxisOption = echarts.YAXisComponentOption;

--- a/easy-to-use-api/klips-chart-api/src/util/Chart.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Chart.ts
@@ -1,10 +1,17 @@
 import {
   DataPointObject,
-  EChartsLineSeriesOption, EChartsXaxisOption, EChartsYaxisOption, TimeSeriesData
+  TimeSeriesData
 } from '../types';
 
-export const createYaxisOptions = (): EChartsYaxisOption => {
-  let option: EChartsYaxisOption;
+// import echart types
+import {
+  LineSeriesOption,
+  XAXisComponentOption,
+  YAXisComponentOption,
+} from 'echarts';
+
+export const createYaxisOptions = (): YAXisComponentOption => {
+  let option: YAXisComponentOption;
   option = {
     type: 'value',
     axisLabel: {
@@ -15,8 +22,8 @@ export const createYaxisOptions = (): EChartsYaxisOption => {
   return option;
 };
 
-export const createXaxisOptions = (inputOptions?: EChartsXaxisOption): EChartsXaxisOption => {
-  let option: EChartsXaxisOption;
+export const createXaxisOptions = (inputOptions?: XAXisComponentOption): XAXisComponentOption => {
+  let option: XAXisComponentOption;
   option = {
     type: 'category',
     boundaryGap: false,
@@ -40,8 +47,8 @@ export const createXaxisOptions = (inputOptions?: EChartsXaxisOption): EChartsXa
   return { ...option, ...inputOptions };
 };
 
-export const createSeriesData = (inputOptions?: EChartsLineSeriesOption): EChartsLineSeriesOption => {
-  let option: EChartsLineSeriesOption;
+export const createSeriesData = (inputOptions?: LineSeriesOption): LineSeriesOption => {
+  let option: LineSeriesOption;
   option = {
     type: 'line',
     silent: false,


### PR DESCRIPTION
- Improve types import for echart
- improve modular import for echart
- reduce bundle size by ~30% (still 700kb!, ideas?)

![image](https://github.com/klips-project/klips-sdi/assets/37144910/f44c3e89-c5f2-4aa7-be24-0dfe32e1973a)

```
vite v4.3.9 building for production...
✓ 641 modules transformed.
dist/index.html                   0.42 kB │ gzip:   0.29 kB
dist/assets/index-c0f34f63.css    0.19 kB │ gzip:   0.16 kB
dist/assets/index-17c20c83.js   722.96 kB │ gzip: 233.41 kB

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 5.55s
```


@weskamm @chrismayer @sdobbert please check.