### PR TITLE
Remove gzip settings in docker nginx

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -10,12 +10,6 @@ server {
     proxy_buffers            4 256k;
     proxy_busy_buffers_size    256k;
 
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 10240;
-    gzip_proxied any;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml application/javascript application/json;
-
     # location for mounted COG data
     location /cog/ {
         root /opt/;


### PR DESCRIPTION
Gzip has been enabled on the native installed ~docker~ nginx on the server to have effect. Can be deleted here.

@chrismayer @weskamm @sdobbert 