### PR TITLE
Add dataset-rotation worker

### DIFF
--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -51,6 +51,11 @@ services:
       context: ../rabbitmq-worker
       dockerfile: ../rabbitmq-worker/src/geotiff-validator/Dockerfile
 
+  dataset-rotation:
+    build:
+      context: ../rabbitmq-worker
+      dockerfile: ../rabbitmq-worker/src/dataset-rotation/Dockerfile
+
   geoserver:
     build: ./geoserver
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,7 +257,7 @@ services:
       - RABBITUSER=${RABBITMQ_DEFAULT_USER}
       - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
       - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
-      - WORKERQUEUE=geotiff-validator
+      - WORKERQUEUE=dataset-rotation
       - PINO_STREAM_LOG_LEVEL
 
   geoserver:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -242,6 +242,24 @@ services:
       - WORKERQUEUE=geotiff-validator
       - PINO_STREAM_LOG_LEVEL
 
+  dataset-rotation:
+    container_name: ${CN_PREFIX}-dataset-rotation
+    image: ghcr.io/klips-project/mqm-worker/dataset-rotation:latest
+    restart: unless-stopped
+    volumes:
+      - ./staging:/opt/staging:Z
+      - ./cog_data:/opt/cog:Z
+      - ./logs:/home/logs:Z
+    depends_on:
+      - rabbitmq
+    environment:
+      - RABBITHOST=${RABBITMQ_HOSTNAME}
+      - RABBITUSER=${RABBITMQ_DEFAULT_USER}
+      - RABBITPASS=${RABBITMQ_DEFAULT_PASS}
+      - RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
+      - WORKERQUEUE=geotiff-validator
+      - PINO_STREAM_LOG_LEVEL
+
   geoserver:
     container_name: ${CN_PREFIX}-geoserver
     image: ghcr.io/klips-project/geoserver:latest

--- a/klips-api/src/converter.ts
+++ b/klips-api/src/converter.ts
@@ -134,17 +134,28 @@ const createGeoTiffPublicationJob = (requestBody: any,
       },
       {
         id: 3,
-        type: 'geotiff-optimizer',
+        type: 'dataset-rotation',
         inputs: [
           {
             outputOfId: 2,
+            outputIndex: 0
+          },
+          cogWebspaceBasePath
+        ]
+      },
+      {
+        id: 4,
+        type: 'geotiff-optimizer',
+        inputs: [
+          {
+            outputOfId: 3,
             outputIndex: 0
           },
           filePathOnWebspace
         ]
       },
       {
-        id: 4,
+        id: 5,
         type: 'geoserver-create-imagemosaic-datastore',
         inputs: [
           geoServerWorkspace,
@@ -153,7 +164,7 @@ const createGeoTiffPublicationJob = (requestBody: any,
         ]
       },
       {
-        id: 5,
+        id: 6,
         type: 'geoserver-publish-imagemosaic',
         inputs: [
           geoServerWorkspace,


### PR DESCRIPTION
The `dataset-rotation` worker manages to delete the oldest dataset, when new data arrives.   
Dependent on: https://github.com/klips-project/rabbitmq-worker/pull/157  

Adapts the job list for the klips-api.

@chrismayer @sdobbert @weskamm 