### PR TITLE
Geometry check

### DIFF
--- a/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
@@ -9,7 +9,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 dayjs.extend(utc);
 
-import { boundaryBox } from '../../constants';
+import { boundingBox } from '../../constants';
 
 // import echart types
 import {
@@ -241,10 +241,9 @@ export class ChartAPI {
       return;
     }
     const wktGeometry = wktReader.read(params.geomwkt);
-    // check if geometry is within boundary box
-    const wktEnvelope = wktGeometry.getEnvelopeInternal();
-    if (!pointInRect(params.region!, boundaryBox, wktEnvelope)) {
-      throw new Error('Point outside of boundary box');
+    // check if point geometry is within boundary box
+    if (!pointInRect(boundingBox[params.region!], wktGeometry)) {
+      throw new Error(`Point coordinates outside of boundary box: ${boundingBox[params.region!].toString()}`);
     }
     // Retrieve chart data from ogc-api-process
     const data = await fetchTimeSeriesData(params, wktGeometry.getCoordinates()[0]);

--- a/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
@@ -9,6 +9,8 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 dayjs.extend(utc);
 
+import { boundaryBox } from '../../constants';
+
 // import echart types
 import {
   EChartsOption,
@@ -55,6 +57,7 @@ import {
   createXaxisOptions,
   createYaxisOptions,
   formatChartData,
+  pointInRect,
   setupBaseChart
 } from '../../util/Chart';
 
@@ -238,6 +241,11 @@ export class ChartAPI {
       return;
     }
     const wktGeometry = wktReader.read(params.geomwkt);
+    // check if geometry is within boundary box
+    const wktEnvelope = wktGeometry.getEnvelopeInternal();
+    if (!pointInRect(params.region!, boundaryBox, wktEnvelope)) {
+      throw new Error('Point outside of boundary box');
+    }
     // Retrieve chart data from ogc-api-process
     const data = await fetchTimeSeriesData(params, wktGeometry.getCoordinates()[0]);
 

--- a/easy-to-use-api/klips-chart-api/src/constants/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/constants/index.ts
@@ -7,6 +7,7 @@ export const pathNameConfig: PathNameConfig = {
   path4: 'threshold'
 };
 
-export const processURL = window.location.href.indexOf('localhost') > -1 ?
-  'http://localhost:5000/processes/location-info-time-rasterstats/execution/' :
-  'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
+export const processURL = 'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
+//  window.location.href.indexOf('localhost') > -1 ?
+  // 'http://localhost:5000/processes/location-info-time-rasterstats/execution/' :
+  // 'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';

--- a/easy-to-use-api/klips-chart-api/src/constants/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/constants/index.ts
@@ -1,4 +1,8 @@
-import { PathNameConfig } from '../types';
+import {
+  BoundingBox,
+  BoundingBoxObject,
+  PathNameConfig
+} from '../types';
 
 // define pathname for widget, e.g. /chart/dresden/Point(xy)/20
 export const pathNameConfig: PathNameConfig = {
@@ -7,22 +11,21 @@ export const pathNameConfig: PathNameConfig = {
   path4: 'threshold'
 };
 
-export const processURL = 'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
-//  window.location.href.indexOf('localhost') > -1 ?
-// 'http://localhost:5000/processes/location-info-time-rasterstats/execution/' :
-// 'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
+export const processURL = window.location.href.indexOf('localhost') > -1 ?
+  'http://localhost:5000/processes/location-info-time-rasterstats/execution/' :
+  'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
 
-export const boundaryBox = {
-  'dresden': {
-    x1: 13.58737,
-    x2: 13.95898,
-    y1: 50.97203,
-    y2: 51.15370
-  },
-  'langenfeld': {
-    x1: 6.91297,
-    x2: 6.99077,
-    y1: 51.08538,
-    y2: 51.13902
-  }
-}
+export const boundingBox: BoundingBoxObject = {
+  dresden: [
+    13.58737,
+    50.97203,
+    13.95898,
+    51.15370
+  ],
+  langenfeld: [
+    6.91297,
+    51.08538,
+    6.99077,
+    51.13902
+  ]
+};

--- a/easy-to-use-api/klips-chart-api/src/constants/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/constants/index.ts
@@ -9,5 +9,20 @@ export const pathNameConfig: PathNameConfig = {
 
 export const processURL = 'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
 //  window.location.href.indexOf('localhost') > -1 ?
-  // 'http://localhost:5000/processes/location-info-time-rasterstats/execution/' :
-  // 'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
+// 'http://localhost:5000/processes/location-info-time-rasterstats/execution/' :
+// 'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
+
+export const boundaryBox = {
+  'dresden': {
+    x1: 13.58737,
+    x2: 13.95898,
+    y1: 50.97203,
+    y2: 51.15370
+  },
+  'langenfeld': {
+    x1: 6.91297,
+    x2: 6.99077,
+    y1: 51.08538,
+    y2: 51.13902
+  }
+}

--- a/easy-to-use-api/klips-chart-api/src/types/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/types/index.ts
@@ -23,3 +23,19 @@ export type Datapoint = [string, string];
 export type DataPointObject = {
   [key: string]: Datapoint[];
 };
+
+export type BoundaryBox = {
+  [property: string]: {
+    x1: number;
+    x2: number;
+    y1: number;
+    y2: number;
+  }
+}
+
+export type Envelope = {
+  _minx: number;
+  _maxx: number;
+  _miny: number;
+  _maxy: number;
+}

--- a/easy-to-use-api/klips-chart-api/src/types/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/types/index.ts
@@ -24,18 +24,13 @@ export type DataPointObject = {
   [key: string]: Datapoint[];
 };
 
-export type BoundaryBox = {
-  [property: string]: {
-    x1: number;
-    x2: number;
-    y1: number;
-    y2: number;
-  }
-}
+export type BoundingBoxObject = {
+  [key: string]: BoundingBox;
+};
 
-export type Envelope = {
-  _minx: number;
-  _maxx: number;
-  _miny: number;
-  _maxy: number;
-}
+export type BoundingBox = [
+  number,
+  number,
+  number,
+  number
+];

--- a/easy-to-use-api/klips-chart-api/src/util/Chart.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Chart.ts
@@ -1,6 +1,8 @@
 import {
   DataPointObject,
-  TimeSeriesData
+  TimeSeriesData,
+  BoundaryBox,
+  Envelope
 } from '../types';
 
 // import echart types
@@ -9,6 +11,16 @@ import {
   XAXisComponentOption,
   YAXisComponentOption,
 } from 'echarts';
+
+// check geometry
+export const pointInRect = (
+  region: string,
+  box: BoundaryBox,
+  point: Envelope,
+): boolean => (
+  (point._minx > box[region].x1 && point._maxx < box[region].x2) &&
+  (point._miny > box[region].y1 && point._maxy < box[region].y2)
+)
 
 export const createYaxisOptions = (): YAXisComponentOption => {
   let option: YAXisComponentOption;

--- a/easy-to-use-api/klips-chart-api/src/util/Chart.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Chart.ts
@@ -1,8 +1,7 @@
 import {
   DataPointObject,
   TimeSeriesData,
-  BoundaryBox,
-  Envelope
+  BoundingBox
 } from '../types';
 
 // import echart types
@@ -14,13 +13,18 @@ import {
 
 // check geometry
 export const pointInRect = (
-  region: string,
-  box: BoundaryBox,
-  point: Envelope,
-): boolean => (
-  (point._minx > box[region].x1 && point._maxx < box[region].x2) &&
-  (point._miny > box[region].y1 && point._maxy < box[region].y2)
-)
+  inputBbox: BoundingBox,
+  point: any
+): boolean => {
+  // get bbox of for input point
+  const envelope = point.getEnvelopeInternal();
+  return (
+    envelope.getMinX() > inputBbox[0] &&
+    envelope.getMinY() > inputBbox[1] &&
+    envelope.getMaxX() < inputBbox[2] &&
+    envelope.getMaxY() < inputBbox[3]
+  );
+};
 
 export const createYaxisOptions = (): YAXisComponentOption => {
   let option: YAXisComponentOption;

--- a/easy-to-use-api/klips-chart-api/src/util/Config.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Config.ts
@@ -14,7 +14,7 @@ export const validateParams = (params: Params) => {
 // check params content
 export const validateParamsRegion = (params: Params) => {
   if (
-    params.region?.includes('dresden') || 
+    params.region?.includes('dresden') ||
     params.region?.includes('langenfeld')
   ) {
     return true;


### PR DESCRIPTION
Checks if point for chart api is within the correct boundary box (Dresden or Langenfeld) and gives a console error if not.

Two pervious commits included here are also included in previous pr: https://github.com/klips-project/klips-sdi/pull/181 
They can be deleted after this pr has been merged.