### PR TITLE
Adds inputs for dataset-rotation worker

### DIFF
--- a/klips-api/src/converter.ts
+++ b/klips-api/src/converter.ts
@@ -138,7 +138,10 @@ const createGeoTiffPublicationJob = (requestBody: any,
         inputs: [
           {
             outputOfId: 2,
-            outputIndex: 0
+            outputIndex: 0,
+            geoServerWorkspace,
+            mosaicStoreName,
+            fileUrlOnWebspace
           },
           cogWebspaceBasePath
         ]


### PR DESCRIPTION
Adds inputs for dataset-rotation worker in order to delete granule from image mosaic.
See: https://github.com/klips-project/rabbitmq-worker/pull/158