### PR TITLE
Add band parameter to chart url

### DIFF
--- a/easy-to-use-api/klips-chart-api/content.json
+++ b/easy-to-use-api/klips-chart-api/content.json
@@ -4,28 +4,32 @@
             "Parameter",
             "region",
             "geomwkt",
-            "threshold"
+            "threshold",
+            "band"
         ],
         [
             "Mögliche Werte",
             "dresden, langenfeld",
             "Punktkoordinate im Koordinatensystem (CRS) WGS84 (EPSG:4326)",
-            "Beliebiger, numerischer Wert"
+            "Beliebiger, numerischer Wert",
+            "perceived, physical, difference, compare"
         ],
         [
             "Beispiel",
             "dresden",
             "POINT(13.740893%2051.056977)",
-            "25.5"
+            "25.5",
+            "physical"
         ],
         [
             "Inhalt",
             "Auswahl einer der beiden Pilotstädte.",
             "Auswahl der Punktkoordinate, für die die Statistiken ausgegeben werden sollen. Muss in der ausgewählten Region (region-Parameter) liegen.",
-            "Auswahl eines Temperatur-Schwellenwertes, der dargestellt werden soll."
+            "Auswahl eines Temperatur-Schwellenwertes, der dargestellt werden soll.",
+            "Auswahl der dargestellten Temperaturvariable: Gefühlte Temperatur ('perceived'), physikalische Temperatur ('physical'), oder Temperaturdifferenz zum Umland ('difference'). 'compare' erlaubt einen Vergleich der Variablen mit der physikalischen Temperatur. Default: Gefühlte Temperatur"
         ]
     ],
     "text": "Definieren Sie eine URL, in der Sie über folgende Parameter Ihre Ausgabe konfigureren können.",
-    "example": "https://klips-dev.terrestris.de/easy-to-use-api/chart/?region=dresden&geomwkt=POINT(13.740893%2051.056977)&threshold=25.5",
+    "example": "https://klips-dev.terrestris.de/easy-to-use-api/chart/?region=dresden&geomwkt=POINT(13.740893%2051.056977)&threshold=25.5&band=physical",
     "title": "KLIPS Chart API: URL Prameter"
 }

--- a/easy-to-use-api/klips-chart-api/content.json
+++ b/easy-to-use-api/klips-chart-api/content.json
@@ -1,34 +1,34 @@
 {
-    "params": [
-        [
+    "params": {
+        "parameter": [
             "Parameter",
             "region",
             "geomwkt",
             "threshold",
             "band"
         ],
-        [
+        "values": [
             "Mögliche Werte",
             "dresden, langenfeld",
             "Punktkoordinate im Koordinatensystem (CRS) WGS84 (EPSG:4326)",
             "Beliebiger, numerischer Wert",
             "perceived, physical, difference, compare"
         ],
-        [
+        "example": [
             "Beispiel",
             "dresden",
             "POINT(13.740893%2051.056977)",
             "25.5",
             "physical"
         ],
-        [
+        "content": [
             "Inhalt",
             "Auswahl einer der beiden Pilotstädte.",
             "Auswahl der Punktkoordinate, für die die Statistiken ausgegeben werden sollen. Muss in der ausgewählten Region (region-Parameter) liegen.",
             "Auswahl eines Temperatur-Schwellenwertes, der dargestellt werden soll.",
             "Auswahl der dargestellten Temperaturvariable: Gefühlte Temperatur ('perceived'), physikalische Temperatur ('physical'), oder Temperaturdifferenz zum Umland ('difference'). 'compare' erlaubt einen Vergleich der Variablen mit der physikalischen Temperatur. Default: Gefühlte Temperatur"
         ]
-    ],
+    },
     "text": "Definieren Sie eine URL, in der Sie über folgende Parameter Ihre Ausgabe konfigureren können.",
     "example": "https://klips-dev.terrestris.de/easy-to-use-api/chart/?region=dresden&geomwkt=POINT(13.740893%2051.056977)&threshold=25.5&band=physical",
     "title": "KLIPS Chart API: URL Prameter"

--- a/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
@@ -86,6 +86,7 @@ export class ChartAPI {
     this.chart = echarts.init(chartDom as HTMLElement);
 
     // select band to display
+    // changes order of imported array 'legendSelect' implicitly. A default order for legendSelect is declared in '../../util/Chart'. The variable is then used to set legend options for setupBaseChart ('../../util/Chart').
     let lineTypeCompare: string = "solid";
     if (params.band?.includes('perceived')) {
       [legendSelect[0], legendSelect[1], legendSelect[2]] = [legendSelect[0], legendSelect[1], legendSelect[2]];

--- a/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
@@ -55,7 +55,8 @@ import {
   createXaxisOptions,
   createYaxisOptions,
   formatChartData,
-  setupBaseChart
+  setupBaseChart,
+  legendSelect
 } from '../../util/Chart';
 
 import WKTParser from 'jsts/org/locationtech/jts/io/WKTParser';
@@ -80,9 +81,22 @@ export class ChartAPI {
 
     if (!chartDom) {
       throw new Error('No div found for chart rendering.');
-    }
+    };
 
     this.chart = echarts.init(chartDom as HTMLElement);
+
+    // select band to display
+    let lineTypeCompare: string = "solid";
+    if (params.band?.includes('perceived')) {
+      [legendSelect[0], legendSelect[1], legendSelect[2]] = [legendSelect[0], legendSelect[1], legendSelect[2]];
+    } else if (params.band?.includes('physical')) {
+      [legendSelect[0], legendSelect[1], legendSelect[2]] = [legendSelect[1], legendSelect[0], legendSelect[2]];
+    } else if (params.band?.includes('difference')) {
+      [legendSelect[0], legendSelect[1], legendSelect[2]] = [legendSelect[2], legendSelect[0], legendSelect[1]];
+    } else if (params.band?.includes('compare')) {
+      [legendSelect[0], legendSelect[1], legendSelect[2]] = [legendSelect[0], legendSelect[0], legendSelect[2]];
+      lineTypeCompare = "dotted"
+    };
 
     // create top xAxis to display timestamps
     const TimeSeries = this.chartData.map((dataPoint) => {
@@ -122,17 +136,21 @@ export class ChartAPI {
     Object.entries(formattedData).forEach(([, dataArray], index) => {
       // TODO define right type
       let name: string = '';
+      let lineType: any = '';
       if (index === 0) {
         name = 'Gefühlte Temperatur';
+        lineType = lineTypeCompare;
       }
       if (index === 1) {
         name = 'Physikalische Temperatur';
       }
       if (index === 2) {
         name = 'Temperaturdifferenz zum Umland';
+        lineType = lineTypeCompare;
       }
       let series = createSeriesData({
         name: name as string,
+        lineStyle: { type: lineType },
         data: dataArray.map(dataPoint => {
           return parseFloat(dataPoint[1]).toFixed(1);
         }),

--- a/easy-to-use-api/klips-chart-api/src/components/Docs/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/components/Docs/index.ts
@@ -1,10 +1,15 @@
-export class ChartAPIDocs {
-    public params: String[];
+
+import {
+    DocsContent
+  } from '../../types';
+  
+  export class ChartAPIDocs {
+    public params: DocsContent;
     public title: String;
     public text: String;
     public example: String;
 
-    constructor(params: String[], title: String, text: String, example: String) {
+    constructor(params: DocsContent, title: String, text: String, example: String) {
         this.params = params;
         this.title = title;
         this.text = text;
@@ -18,12 +23,12 @@ export class ChartAPIDocs {
         const docElement: HTMLElement | null = document.querySelector('#url-params-documentation');
         if (docElement) {
             let table = '';
-            for (let i = 0; i < this.params[0].length; i++) {
+            for (let i = 0; i < this.params.parameter.length; i++) {
                 let tr = '<tr>';
-                tr += '<td>' + this.params[0][i] + '</td>';
-                tr += '<td>' + this.params[1][i] + '</td>';
-                tr += '<td>' + this.params[2][i] + '</td>';
-                tr += '<td>' + this.params[3][i] + '</td>';
+                tr += '<td>' + this.params.parameter[i] + '</td>';
+                tr += '<td>' + this.params.values[i] + '</td>';
+                tr += '<td>' + this.params.example[i] + '</td>';
+                tr += '<td>' + this.params.content[i] + '</td>';
                 tr += '</tr>';
                 table += tr;
             }

--- a/easy-to-use-api/klips-chart-api/src/components/Docs/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/components/Docs/index.ts
@@ -18,7 +18,7 @@ export class ChartAPIDocs {
         const docElement: HTMLElement | null = document.querySelector('#url-params-documentation');
         if (docElement) {
             let table = '';
-            for (let i = 0; i < this.params.length; i++) {
+            for (let i = 0; i < this.params[0].length; i++) {
                 let tr = '<tr>';
                 tr += '<td>' + this.params[0][i] + '</td>';
                 tr += '<td>' + this.params[1][i] + '</td>';
@@ -27,7 +27,7 @@ export class ChartAPIDocs {
                 tr += '</tr>';
                 table += tr;
             }
-            
+
             const header = `<div id='heading'><span> ${this.title} </span></div><span> ${this.text} </span>`
             const example = `<span> Beispiel-URL: </span><a href = ${this.example}>${this.example}</a>`
 

--- a/easy-to-use-api/klips-chart-api/src/constants/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/constants/index.ts
@@ -7,7 +7,8 @@ import {
 export const pathNameConfig: PathNameConfig = {
   path2: 'region',
   path3: 'geomwkt',
-  path4: 'threshold'
+  path4: 'threshold',
+  path5: 'band'
 };
 
 export const processURL = window.location.href.indexOf('localhost') > -1 ?

--- a/easy-to-use-api/klips-chart-api/src/types/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/types/index.ts
@@ -14,6 +14,13 @@ export type PathNameConfig = {
   [pathName: string]: string;
 };
 
+export type DocsContent = {
+  parameter: String[];
+  values: String[];
+  example: String[];
+  content: String[];
+};
+
 export type TimeSeriesDatapoint = {
   [bandName: string]: string;
   'timestamp': string;

--- a/easy-to-use-api/klips-chart-api/src/types/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/types/index.ts
@@ -2,6 +2,7 @@ export type Params = {
   region?: string;
   geomwkt?: string;
   threshold?: string;
+  band?: string;
   currentTimestamp?: string;
   startTimestamp?: string;
   endTimestamp?: string;
@@ -36,3 +37,17 @@ export type BoundingBox = [
   number,
   number
 ];
+
+export type LegendSelect = [ {
+  name?: string;
+  icon?: string
+},
+{
+  name?: string;
+  icon?: string
+},
+{
+  name?: string;
+  icon?: string
+}
+]

--- a/easy-to-use-api/klips-chart-api/src/util/Chart.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Chart.ts
@@ -118,7 +118,7 @@ export const createVisualMap = (threshold: number): echarts.VisualMapComponentOp
   };
 };
 
-export let legendSelect: LegendSelect = [
+export const legendSelect: LegendSelect = [
   {
     name: 'Gefühlte Temperatur',
     icon: 'none'

--- a/easy-to-use-api/klips-chart-api/src/util/Chart.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Chart.ts
@@ -1,7 +1,8 @@
 import {
   DataPointObject,
   TimeSeriesData,
-  BoundingBox
+  BoundingBox,
+  LegendSelect,
 } from '../types';
 
 // import echart types
@@ -67,7 +68,7 @@ export const createSeriesData = (inputOptions?: LineSeriesOption): LineSeriesOpt
   option = {
     type: 'line',
     silent: false,
-    showSymbol: true,
+    showSymbol: false,
     xAxisIndex: 1,
     lineStyle: {
       width: 3,
@@ -117,6 +118,21 @@ export const createVisualMap = (threshold: number): echarts.VisualMapComponentOp
   };
 };
 
+export let legendSelect: LegendSelect = [
+  {
+    name: 'Gefühlte Temperatur',
+    icon: 'none'
+  },
+  {
+    name: 'Physikalische Temperatur',
+    icon: 'none'
+  },
+  {
+    name: 'Temperaturdifferenz zum Umland',
+    icon: 'none',
+  }
+];
+
 export const setupBaseChart = (): echarts.EChartsOption => {
   return {
     title: {
@@ -126,22 +142,9 @@ export const setupBaseChart = (): echarts.EChartsOption => {
       trigger: 'axis',
     },
     legend: {
-      data: [
-        {
-          name: 'Gefühlte Temperatur',
-          icon: 'none'
-        },
-        {
-          name: 'Physikalische Temperatur',
-          icon: 'none'
-        },
-        {
-          name: 'Temperaturdifferenz zum Umland',
-          icon: 'none'
-        }
-      ],
+      data: legendSelect,
       selectedMode: 'single',
-      bottom: 50
+      bottom: 50,
     },
     xAxis: [],
     yAxis: [],


### PR DESCRIPTION
Adds a parameter "band" to the chart url to select which band (physical temperature, perceived temperature, or temperature difference) is displayed first in the chart.

Options are physical, perceived, difference, and compare with the compare option showing physical temperature and either perceived or temperature difference in one graph for direct comparison.

Default is perceived temperature.

example: /?region=dresden&geomwkt=POINT(13.77509%2051.06778)&threshold=22.5&band=compare
![image](https://github.com/klips-project/klips-sdi/assets/132580338/41d65a73-d006-4546-a78f-9e08ff865d1e)


@hblitza @chrismayer 