### PR TITLE
Create chart for polygon (mean values)

### DIFF
--- a/easy-to-use-api/klips-chart-api/package-lock.json
+++ b/easy-to-use-api/klips-chart-api/package-lock.json
@@ -18,6 +18,8 @@
         "@testing-library/dom": "^9.3.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@types/jest": "^29.5.1",
+        "@types/jsts": "^0.17.18",
+        "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
         "eslint-plugin-import": "^2.27.5",
         "jest": "^29.5.0",
@@ -116,9 +118,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -168,9 +170,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1877,10 +1879,25 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/jsts": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@types/jsts/-/jsts-0.17.18.tgz",
+      "integrity": "sha512-T+VN12+iRqvgJLMo9IXA/PxgCs/pF2x1FSApzaZf4thprAm6488j8n+ri650tgkWw9gaaUhlj6InAInVvSXEBQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/openlayers": "*"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.4.tgz",
-      "integrity": "sha512-At4pvmIOki8yuwLtd7BNHl3CiWNbtclUbNtScGx4OHfBd4/oWoJC8KRCIxXwkdndzhxOsPXihrsOoydxBjlE9Q=="
+      "version": "20.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
+    },
+    "node_modules/@types/openlayers": {
+      "version": "4.6.19",
+      "resolved": "https://registry.npmjs.org/@types/openlayers/-/openlayers-4.6.19.tgz",
+      "integrity": "sha512-hw1SEVGOIZmF/XjO49dnUF6AVPvxZFh1KU5KIzDsSeysDUbWBZSK3PM2V/BNy2ABmpKJluQxjOAAF1Sr+oQ+PA==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -3380,9 +3397,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4563,9 +4580,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5444,9 +5461,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -6287,9 +6304,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"

--- a/easy-to-use-api/klips-chart-api/package.json
+++ b/easy-to-use-api/klips-chart-api/package.json
@@ -23,6 +23,8 @@
     "@testing-library/dom": "^9.3.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@types/jest": "^29.5.1",
+    "@types/jsts": "^0.17.18",
+    "@types/node": "^20.4.5",
     "@typescript-eslint/eslint-plugin": "^5.59.5",
     "eslint-plugin-import": "^2.27.5",
     "jest": "^29.5.0",

--- a/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/components/Chart/index.ts
@@ -258,14 +258,15 @@ export class ChartAPI {
     params.endTimestamp = endTimestamp;
 
     // Retrieve chart data from ogc-api-process
-    if (!params.geomwkt) {
+    if (!params.geom) {
       return;
     }
 
-    // adapt geomwkt format
-    if (params.geomwkt.includes('Polygon')) {
-      params.geomwkt = 'POLYGON(' +
-        JSON.parse(params.geomwkt).coordinates.map(function (ring: any) {
+    // adapt geometry format
+    // if geom-parameter is not given in WKT-format in the url, the parameter is reformatted here.
+    if (params.geom.includes('Polygon')) {
+      params.geom = 'POLYGON(' +
+        JSON.parse(params.geom).coordinates.map(function (ring: any) {
           return '(' + ring.map(function (p: any) {
             return p[0] + ' ' + p[1];
           }).join(', ') + ')';
@@ -273,7 +274,7 @@ export class ChartAPI {
     }
     // get wkt Geometry
     const wktReader = new WKTParser();
-    const wktGeometry = wktReader.read(params.geomwkt);
+    const wktGeometry = wktReader.read(params.geom);
     params.wktGeometry = wktGeometry;
 
     // get GeoJSON
@@ -286,7 +287,7 @@ export class ChartAPI {
 
     // get data
     let data: TimeSeriesData;
-    if (params.geomwkt.includes('POLYGON')) {
+    if (params.geom.includes('POLYGON')) {
       data = await fetchTimeSeriesDataPolygon(params, params.geoJSONGeometry);
     } else {
       data = await fetchTimeSeriesData(params, wktGeometry.getCoordinates()[0]);

--- a/easy-to-use-api/klips-chart-api/src/constants/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/constants/index.ts
@@ -12,8 +12,13 @@ export const pathNameConfig: PathNameConfig = {
 };
 
 export const processURL = window.location.href.indexOf('localhost') > -1 ?
-'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution' :
+  'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution' :
   'https://klips-dev.terrestris.de/processes/location-info-time-rasterstats/execution';
+
+export const processURLPolygon = window.location.href.indexOf('localhost') > -1 ?
+  'https://klips-dev.terrestris.de/processes/zonal-statistics-time-rasterstats/execution' :
+  'https://klips-dev.terrestris.de/processes/zonal-statistics-time-rasterstats/execution';
+
 
 export const boundingBox: BoundingBoxObject = {
   dresden: [

--- a/easy-to-use-api/klips-chart-api/src/constants/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/constants/index.ts
@@ -6,9 +6,9 @@ import {
 // define pathname for widget, e.g. /chart/dresden/Point(xy)/20
 export const pathNameConfig: PathNameConfig = {
   path2: 'region',
-  path3: 'geomwkt',
+  path3: 'geom',
   path4: 'threshold',
-  path5: 'band'
+  path5: 'band',
 };
 
 export const processURL = window.location.href.indexOf('localhost') > -1 ?

--- a/easy-to-use-api/klips-chart-api/src/service/ogc-api-service/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/service/ogc-api-service/index.ts
@@ -93,7 +93,7 @@ export const generateErrorMessages = (
   if (!pointInRect(boundingBox[params.region!], params.wktGeometry)) {
     if (errorElementURL) {
       errorElementURL.style.display = 'block';
-      errorElementURL.innerHTML = `<div><span>Ungültige Koordinateneingabe. Die eingegebenen Koordinaten liegen nicht in der ausgewählten Region. Bitte prüfen Sie die eingegebenen Parameter für "geomwkt".</span></div>${linkDocsHTML}`;
+      errorElementURL.innerHTML = `<div><span>Ungültige Koordinateneingabe. Die eingegebenen Koordinaten liegen nicht in der ausgewählten Region. Bitte prüfen Sie die eingegebenen Parameter für "geom".</span></div>${linkDocsHTML}`;
     }
     throw new Error(`Point coordinates outside of boundary box: ${boundingBox[params.region!].toString()}`);
   }

--- a/easy-to-use-api/klips-chart-api/src/service/ogc-api-service/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/service/ogc-api-service/index.ts
@@ -1,5 +1,5 @@
 import { Params } from '../../types';
-import { processURL, boundingBox } from '../../constants';
+import { processURL, processURLPolygon, boundingBox } from '../../constants';
 import { validateParams, validateParamsRegion } from '../../util/Config';
 import { pointInRect } from '../../util/Chart';
 
@@ -19,6 +19,37 @@ export const fetchTimeSeriesData = async (
     }
   };
   const url = processURL;
+  const response = await fetch(url, {
+    body: JSON.stringify(body),
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error status: ${response.status}`);
+  }
+
+  return await response.json();
+};
+
+export const fetchTimeSeriesDataPolygon = async (
+  params: Params,
+  coordinates: any
+): Promise<any> => {
+  const body = {
+    inputs: {
+      polygonGeoJson: coordinates,
+      cogDirUrl: `http://nginx/cog/${params.region}/${params.region}_temperature/`,
+      statisticMethods: ['mean', 'max', 'min'],
+      inputCrs: 'EPSG:4326',
+      startTimeStamp: params.startTimestamp,
+      endTimeStamp: params.endTimestamp,
+      bands: [1, 2, 3]
+    }
+  };
+  const url = processURLPolygon;
   const response = await fetch(url, {
     body: JSON.stringify(body),
     method: 'POST',

--- a/easy-to-use-api/klips-chart-api/src/types/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/types/index.ts
@@ -1,6 +1,6 @@
 export type Params = {
   region?: string;
-  geomwkt?: string;
+  geom?: string;
   threshold?: string;
   band?: string;
   currentTimestamp?: string;

--- a/easy-to-use-api/klips-chart-api/src/types/index.ts
+++ b/easy-to-use-api/klips-chart-api/src/types/index.ts
@@ -8,6 +8,7 @@ export type Params = {
   endTimestamp?: string;
   pointInRegion?: string;
   wktGeometry?: string;
+  geoJSONGeometry?: string;
 };
 
 export type PathNameConfig = {

--- a/easy-to-use-api/klips-chart-api/src/util/Chart.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Chart.ts
@@ -82,7 +82,8 @@ export const createSeriesData = (inputOptions?: LineSeriesOption): LineSeriesOpt
 
 export const formatChartData = (data: TimeSeriesData): DataPointObject => {
   const result: DataPointObject = {};
-  data.forEach(obj => {
+  if (!data[0].band) {
+    data.forEach(obj => {
     Object.keys(obj).forEach((key, index) => {
       if (key !== 'timestamp') {
         if (!result[key]) {
@@ -95,7 +96,12 @@ export const formatChartData = (data: TimeSeriesData): DataPointObject => {
         );
       }
     });
-  });
+  }); } else {
+    data.map(band => band.band)
+    .filter((value, index, self) => self.indexOf(value) === index).forEach(value => {
+      result[value] = data.filter(item => item.band === value).map(item => [item.timestamp, item.mean]);
+    });
+  }
   return result;
 };
 

--- a/easy-to-use-api/klips-chart-api/src/util/Chart.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Chart.ts
@@ -82,25 +82,31 @@ export const createSeriesData = (inputOptions?: LineSeriesOption): LineSeriesOpt
 
 export const formatChartData = (data: TimeSeriesData): DataPointObject => {
   const result: DataPointObject = {};
+  // for point geometry 
   if (!data[0].band) {
     data.forEach(obj => {
-    Object.keys(obj).forEach((key, index) => {
-      if (key !== 'timestamp') {
-        if (!result[key]) {
-          result[key] = [];
+      Object.keys(obj).forEach((key, index) => {
+        if (key !== 'timestamp') {
+          if (!result[key]) {
+            result[key] = [];
+          }
+          result[key].push([
+            obj.timestamp,
+            obj[`band_${index + 1}`]
+          ]
+          );
         }
-        result[key].push([
-          obj.timestamp,
-          obj[`band_${index + 1}`]
-        ]
-        );
-      }
+      });
+      // for polygon geometry
+      // output structure of the ogc-api-process zonal-statistics-time-rasterstats gives output as individual objects for each band. Thus the output data is restructured here.
     });
-  }); } else {
+  } else {
     data.map(band => band.band)
-    .filter((value, index, self) => self.indexOf(value) === index).forEach(value => {
-      result[value] = data.filter(item => item.band === value).map(item => [item.timestamp, item.mean]);
-    });
+      .filter((value, index, self) => self.indexOf(value) === index) // get number of bands
+      .forEach(value => {
+        result[value] = data.filter(item => item.band === value) // filter data array by each band number
+        .map(item => [item.timestamp, item.mean]); // map the correct parameters to each object
+      });
   }
   return result;
 };

--- a/easy-to-use-api/klips-chart-api/src/util/Config.ts
+++ b/easy-to-use-api/klips-chart-api/src/util/Config.ts
@@ -3,8 +3,8 @@ import { Params } from '../types';
 export const validateParams = (params: Params) => {
   if (
     params.hasOwnProperty('region') &&
-    params.hasOwnProperty('geomwkt') 
-   // params.hasOwnProperty('threshold')
+    params.hasOwnProperty('geom') &&
+    // params.hasOwnProperty('threshold')
   ) {
     return true;
   }


### PR DESCRIPTION
Adapts the KLIPS-Chart-API for an Input-Polygon, which is specified in the URL. Mean values are created using zonal statistics (zonal_statistics_time_rasterstats).

Example URL:
/?region=dresden&geomwkt={"coordinates":%20[[[13.72242,%2051.04242],[13.72242,%2051.06019],[13.74525,%2051.06019],[13.74525,%2051.04242],[13.72242,%2051.04242]]],"type":%20"Polygon"}&threshold=25 

or for WKT-Input:
/?region=dresden&geomwkt=POLYGON((13.72242%2051.04242,%2013.72242%2051.06019,%2013.74525%2051.06019,%2013.74525%2051.04242,%2013.72242%2051.04242))&threshold=25&band=physical