### PR TITLE
repair pygeoapi test

### DIFF
--- a/.github/workflows/test-pygeoapi.yml
+++ b/.github/workflows/test-pygeoapi.yml
@@ -22,11 +22,7 @@ jobs:
       - name: Ensures job is exited on error
         run: set -e
       - name: Run nginx-test container to create a dummy webspace for the test
-        run: docker run \
-          -d --name nginx-test \
-          -v ${pwd}/pygeoapi/dev_scripts/default.conf:/etc/nginx/conf.d/default.conf \
-          -v ${pwd}/mocked-webspace/:/usr/share/nginx/html \
-          -p 81:80 nginx
+        run: docker run -d --name nginx-test -v $(pwd)/pygeoapi/dev_scripts/default.conf:/etc/nginx/conf.d/default.conf -v $(pwd)/mocked-webspace/:/usr/share/nginx/html -p 81:80 nginx
       - name: Wait until dummy webspace is available
         run: wait-for-it "localhost:81"
       - name: Checkout repository

--- a/.github/workflows/test-pygeoapi.yml
+++ b/.github/workflows/test-pygeoapi.yml
@@ -21,10 +21,12 @@ jobs:
           pip install flake8 pytest black rio-cogeo rasterstats
       - name: Ensures job is exited on error
         run: set -e
-      - name: Provide a .env file for running the docker-compose setup
-        run: cp .env.example .env
-      - name: Run NGINX from docker-compose setup to create a dummy webspace for the test
-        run: docker-compose -f docker-compose.yml up -d nginx
+      - name: Run nginx-test container to create a dummy webspace for the test
+        run: docker run \
+          -d --name nginx-test \
+          -v $(pwd)/pygeoapi/dev_scripts/default.conf:/etc/nginx/conf.d/default.conf \
+          -v $(pwd)/mocked-webspace/:/usr/share/nginx/html \
+          -p 81:80 nginx
       - name: Wait until dummy webspace is available
         run: wait-for-it "localhost:81"
       - name: Checkout repository

--- a/.github/workflows/test-pygeoapi.yml
+++ b/.github/workflows/test-pygeoapi.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Run nginx-test container to create a dummy webspace for the test
         run: docker run \
           -d --name nginx-test \
-          -v $(pwd)/pygeoapi/dev_scripts/default.conf:/etc/nginx/conf.d/default.conf \
-          -v $(pwd)/mocked-webspace/:/usr/share/nginx/html \
+          -v ${pwd}/pygeoapi/dev_scripts/default.conf:/etc/nginx/conf.d/default.conf \
+          -v ${pwd}/mocked-webspace/:/usr/share/nginx/html \
           -p 81:80 nginx
       - name: Wait until dummy webspace is available
         run: wait-for-it "localhost:81"

--- a/pygeoapi/Dockerfile
+++ b/pygeoapi/Dockerfile
@@ -12,7 +12,7 @@ RUN apt -y update && \
 # NOTE: ensure the minor versions of added libraries are compatible with each other,
 #       otherwise pygeoapi might not start up at all
 
-RUN pip3 install rasterstats click==7.1.2 rio-cogeo==3.4.1 shapely==2.0.1 ffmpeg-python==0.2.0 Pillow==9.4.0 pygml==0.2.2 lxml==4.9.2 debugpy==1.6.7
+RUN pip3 install rasterstats click==7.1.2 rio-cogeo==3.4.1 shapely==2.0.1 ffmpeg-python==0.2.0 Pillow==9.4.0 pygml==0.2.2 lxml==4.9.2 debugpy==1.6.7 pytz==2023.3.post1requests==2.31.0 
 
 COPY demo_data/ /demo_data/
 

--- a/pygeoapi/dev_scripts/default.conf
+++ b/pygeoapi/dev_scripts/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        autoindex_format json;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/pygeoapi/processes/algorithms/timelapse_video.py
+++ b/pygeoapi/processes/algorithms/timelapse_video.py
@@ -15,10 +15,7 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 url = os.environ["SERVER_URL"]
-geoserverUrl = (
-    url 
-    + "/geoserver/dresden/wms?"
-)
+geoserverUrl = url + "/geoserver/dresden/wms?"
 baseurl = (
     geoserverUrl
     + "SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&STYLES&LAYERS=dresden%3Adresden_temperature&exceptions=application%2Fvnd.ogc.se_inimage&SRS=EPSG%3A3035&"  # noqa: E501


### PR DESCRIPTION
This should fix the failing pygeoapi lint and test pipeline, cf. https://github.com/klips-project/klips-sdi/actions/workflows/test-pygeoapi.yml  

Issues fixed:
- do not start docker-compose, use `docker run` to only run the test-nginx container
- fix pylint errors

@chrismayer @FritzHoing @sdobbert please note