### PR TITLE
demonstrator styling

### DIFF
--- a/demonstrator-ogc-services/klips-wmts-demo/src/App.less
+++ b/demonstrator-ogc-services/klips-wmts-demo/src/App.less
@@ -19,7 +19,18 @@
 
 #transparency-slider {
   display: none;
-  margin: 1%;
+  position: absolute;
+  background-color: white;
+  padding: 1vh;
+  width: 20%;
+  right: 30px;
+  bottom: 160px;
+}
+
+#buttons {
+  position: fixed;
+  top: 75px;
+  right: 22px;
 }
 
 #legend {
@@ -27,9 +38,10 @@
   width: auto;
   display: none;
   height: auto;
-  bottom: 0;
-  right: 0;
   background-color:  white;
+  padding: 1vh;
+  right: 30px;
+  bottom: 160px;
   margin-bottom: 35vh;
 }
 

--- a/demonstrator-ogc-services/klips-wmts-demo/src/App.less
+++ b/demonstrator-ogc-services/klips-wmts-demo/src/App.less
@@ -41,8 +41,7 @@
   background-color:  white;
   padding: 1vh;
   right: 30px;
-  bottom: 160px;
-  margin-bottom: 35vh;
+  bottom: 240px;
 }
 
 img {

--- a/demonstrator-ogc-services/klips-wmts-demo/src/App.tsx
+++ b/demonstrator-ogc-services/klips-wmts-demo/src/App.tsx
@@ -79,7 +79,6 @@ export const App: React.FC = (): JSX.Element => {
   };
 
   // get legend
-  // since the style of the params is equal it doesn't matter which Params we recieve
   const layerName = src.getParams().LAYERS[1];
   const legendUrl = 'https://klips-dev.terrestris.de/geoserver/wms?REQUEST=GetLegendGraphic&VERSION=1.0.0&'
     + `FORMAT=image/png&WIDTH=20&HEIGHT=15&STRICT=false&LAYER=${layerName}`;
@@ -103,6 +102,11 @@ export const App: React.FC = (): JSX.Element => {
             onChangeLayer={changeLayer}
           />
         </div>
+        <div id='transparency-slider' >
+          <LayerTransparencySlider
+            layer={selectedLayer}
+          />
+        </div>
       </div>
       <div id='slider' >
         <BasicTimeSlider
@@ -110,23 +114,20 @@ export const App: React.FC = (): JSX.Element => {
           max={48}
           layers={layers}
         />
-        <SimpleButton
-          className="toggle-button"
-          onClick={toggleHidden}
-        >
-          {t('Button.opacity')}
-        </SimpleButton>
-        <SimpleButton
-          className="toggle-button"
-          onClick={toggleLegend}
-        >
-          {t('Button.legend')}
-        </SimpleButton>
-        <div id='transparency-slider' >
-          <LayerTransparencySlider
-            layer={selectedLayer}
-          />
-        </div >
+        <div id='buttons' >
+          <SimpleButton
+            className="toggle-button"
+            onClick={toggleHidden}
+          >
+            {t('Button.opacity')}
+          </SimpleButton>
+          <SimpleButton
+            className="toggle-button"
+            onClick={toggleLegend}
+          >
+            {t('Button.legend')}
+          </SimpleButton>
+        </div>
         <div id='legend' >
           {legend}
         </div>

--- a/demonstrator-ogc-services/klips-wmts-demo/src/components/BasicLayerSelector/index.less
+++ b/demonstrator-ogc-services/klips-wmts-demo/src/components/BasicLayerSelector/index.less
@@ -1,6 +1,6 @@
 .bg-layer-chooser {
   position: fixed;
-  top: 7%;
+  top: 120px;
   right: 30px;
   width: 400px;
 }

--- a/demonstrator-ogc-services/klips-wmts-slider/src/App.less
+++ b/demonstrator-ogc-services/klips-wmts-slider/src/App.less
@@ -17,9 +17,20 @@
   background-color: white;
 }
 
+#buttons {
+  position: fixed;
+  top: 70px;
+  right: 22px;
+}
+
 #transperency-slider {
   display: none;
-  margin: 2%;
+  position: absolute;
+  background-color: white;
+  padding: 1vh;
+  width: 20%;
+  right: 30px;
+  bottom: 160px;
 }
 
 #legend {
@@ -27,10 +38,10 @@
   width: auto;
   display: none;
   height: auto;
-  bottom: 0;
-  right: 0;
   background-color:  white;
-  margin-bottom: 30vh;
+  padding: 1vh;
+  right: 30px;
+  top: 12vh;
 }
 
 img {

--- a/demonstrator-ogc-services/klips-wmts-slider/src/App.less
+++ b/demonstrator-ogc-services/klips-wmts-slider/src/App.less
@@ -25,7 +25,7 @@
 
 #transperency-slider {
   display: none;
-  position: absolute;
+  position: fixed;
   background-color: white;
   padding: 1vh;
   width: 20%;
@@ -34,14 +34,14 @@
 }
 
 #legend {
-  position: absolute;
+  position: fixed;
   width: auto;
   display: none;
   height: auto;
   background-color:  white;
   padding: 1vh;
   right: 30px;
-  top: 12vh;
+  bottom: 300px;
 }
 
 img {

--- a/demonstrator-ogc-services/klips-wmts-slider/src/App.tsx
+++ b/demonstrator-ogc-services/klips-wmts-slider/src/App.tsx
@@ -110,18 +110,20 @@ export const App: React.FC = (): JSX.Element => {
           date={'2023-01-01'}
           layers={layers}
         />
-        <SimpleButton
-          className="toggle-button"
-          onClick={toggleHidden}
-        >
-          {t('Button.opacity')}
-        </SimpleButton>
-        <SimpleButton
-          className="toggle-button"
-          onClick={toggleLegend}
-        >
-          {t('Button.legend')}
-        </SimpleButton>
+        <div id='buttons' >
+          <SimpleButton
+            className="toggle-button"
+            onClick={toggleHidden}
+          >
+            {t('Button.opacity')}
+          </SimpleButton>
+          <SimpleButton
+            className="toggle-button"
+            onClick={toggleLegend}
+          >
+            {t('Button.legend')}
+          </SimpleButton>
+        </div>
         <div id='transperency-slider' >
           <div>
             <span>{labelFirstLayer}</span>

--- a/demonstrator-ogc-services/klips-wmts-slider/src/components/BasicSwipe/index.tsx
+++ b/demonstrator-ogc-services/klips-wmts-slider/src/components/BasicSwipe/index.tsx
@@ -136,7 +136,7 @@ const BasicSwipe: React.FC<BasicSwipeProps> = ({
     map.render();
   };
 
-  const top = 7 + 'vh';
+  const top = 12 + 'vh';
   const padding = 11 + 'px';
   const left = labelPosition - 15 + 'px';
   const right = labelPosition - 130 + 'px';

--- a/demonstrator-ogc-services/klips-wmts-slider/src/index.less
+++ b/demonstrator-ogc-services/klips-wmts-slider/src/index.less
@@ -37,7 +37,6 @@ align-items: center;
 .ant-row {
   display: flex;
   flex-wrap: nowrap;
-  padding-bottom: 3%;
   justify-content: space-evenly;
 }
 


### PR DESCRIPTION
Unifies the style of the WMTS-demonstrators (klips-wmts-slider, klips-wmts-simulation, and klips-wmts-demo).
Legends and optional windows are now shown on the right, leaving more room for the map:

![image](https://github.com/klips-project/klips-sdi/assets/132580338/e0dbcf4b-10ca-4ac1-a8ff-c59f76fdfef5)
