### PR TITLE
fix: using correct input now

### DIFF
--- a/klips-api/src/converter.ts
+++ b/klips-api/src/converter.ts
@@ -170,7 +170,7 @@ const createGeoTiffPublicationJob = (requestBody: any,
         type: 'dataset-archive',
         inputs: [
           {
-            outputOfId: 2,
+            outputOfId: 4,
             outputIndex: 0
           },
           cogWebspaceBasePath


### PR DESCRIPTION
Before the output of the geotiff-validator was used as an input for the archive. But that output is deleted within the geotiff-optimizer worker. So now the output of id 4 (geotiff-optimizer: cog's) is used as the input for the archive. 