### PR TITLE
Decrease memory allocation for geoserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -377,7 +377,7 @@ services:
     environment:
       - INSTALL_EXTENSIONS=true
       - STABLE_EXTENSIONS=importer,wps
-      - EXTRA_JAVA_OPTS=-Xms1g -Xmx32g
+      - EXTRA_JAVA_OPTS=-Xms1g -Xmx24g
       - SKIP_DEMO_DATA=true
       - GEOSERVER_CSRF_DISABLED=true
     healthcheck:


### PR DESCRIPTION
Sets maximum memory for geoserver to 24GB.

